### PR TITLE
[Feat#6] team 생성 및 조회 api 추가

### DIFF
--- a/.github/workflows/blue-green-deploy.yml
+++ b/.github/workflows/blue-green-deploy.yml
@@ -118,6 +118,10 @@ jobs:
             KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
             BACKEND_URL=${{ secrets.BACKEND_URL }}
             REDIS_HOST=${{ secrets.REDIS_HOST }}
+            GCP_CDN_DOMAIN=${{ secrets.GCP_CDN_DOMAIN }}
+            GCS_KEY=${{ secrets.GCS_KEY }}
+            GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
+            BUCKET_NAME=${{ secrets.BUCKET_NAME }}
             DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}
             VERSION=${{ env.VERSION }}
             BLUE_PORT=${{ env.BLUE_PORT }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,10 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // GCS
+    implementation("org.springframework.cloud", "spring-cloud-gcp-starter", "1.2.5.RELEASE")
+    implementation("org.springframework.cloud", "spring-cloud-gcp-storage", "1.2.5.RELEASE")
 }
 
 kotlin {

--- a/src/main/kotlin/com/jipsa/balearn/api/mission/dto/MissionReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission/dto/MissionReadResponse.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.api.mission.dto
+
+import com.jipsa.balearn.domain.mission.Mission
+import com.jipsa.balearn.domain.notice.Notice
+import org.springframework.data.jpa.domain.AbstractAuditable_.createdBy
+import java.time.LocalDateTime
+
+data class MissionReadResponse(
+    val id: Long,
+    val detail: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: Long?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: Long?
+) {
+    companion object {
+        fun from(mission: Mission): MissionReadResponse {
+            return MissionReadResponse(
+                id = mission.id.value,
+                detail = mission.missionInfo.detail,
+                createdAt = mission.createdAt,
+                createdBy = mission.createdBy?.value,
+                modifiedAt = mission.modifiedAt,
+                modifiedBy = mission.modifiedBy?.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/notice/dto/NoticeReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/notice/dto/NoticeReadResponse.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.api.notice.dto
+
+import com.jipsa.balearn.domain.notice.Notice
+import java.time.LocalDateTime
+
+data class NoticeReadResponse(
+    val id: Long,
+    val title: String,
+    val detail: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: Long?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: Long?
+) {
+    companion object {
+        fun from(notice: Notice): NoticeReadResponse {
+            return NoticeReadResponse(
+                id = notice.id.value,
+                title = notice.noticeInfo.title,
+                detail = notice.noticeInfo.detail,
+                createdAt = notice.createdAt,
+                createdBy = notice.createdBy?.value,
+                modifiedAt = notice.modifiedAt,
+                modifiedBy = notice.modifiedBy?.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/schedule/dto/ScheduleReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/schedule/dto/ScheduleReadResponse.kt
@@ -1,0 +1,26 @@
+package com.jipsa.balearn.api.schedule.dto
+
+import com.jipsa.balearn.api.mission.dto.MissionReadResponse
+import com.jipsa.balearn.domain.mission.Mission
+import com.jipsa.balearn.domain.schedule.Schedule
+import java.time.LocalDateTime
+
+data class ScheduleReadResponse(
+    val id: Long,
+    val address: String,
+    val time: LocalDateTime,
+    val topic: String,
+    val mission: List<MissionReadResponse>
+) {
+    companion object {
+        fun from(schedule: Schedule, missions: List<Mission>): ScheduleReadResponse {
+            return ScheduleReadResponse(
+                id = schedule.id.value,
+                address = schedule.scheduleInfo.address,
+                time = schedule.scheduleInfo.time,
+                topic = schedule.scheduleInfo.topic,
+                mission = missions.map { MissionReadResponse.from(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
@@ -1,0 +1,39 @@
+package com.jipsa.balearn.api.team
+
+import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.api.team.dto.TeamCreateRequest
+import com.jipsa.balearn.api.team.dto.TeamCreateResponse
+import com.jipsa.balearn.common.api.ApiResponse
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team.TeamService
+import com.jipsa.balearn.domain.user.User
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/team")
+class TeamApi(
+    private val teamService: TeamService
+) {
+    @PostMapping("/create")
+    fun createTeam(
+        @RequestPart("data") request: TeamCreateRequest,
+        @RequestPart("image", required = false) image: MultipartFile?,
+        @CurrentUser user: User
+    ): ApiResponse<TeamCreateResponse> {
+        return ApiResponse.success(
+            TeamCreateResponse.from(
+                teamService.createTeam(
+                    name = request.name,
+                    description = request.description,
+                    goals = request.goals,
+                    image = image?.let { File.from(it) },
+                    user = user
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
@@ -3,14 +3,13 @@ package com.jipsa.balearn.api.team
 import com.jipsa.balearn.api.global.annotation.CurrentUser
 import com.jipsa.balearn.api.team.dto.TeamCreateRequest
 import com.jipsa.balearn.api.team.dto.TeamCreateResponse
+import com.jipsa.balearn.api.team.dto.TeamResponse
 import com.jipsa.balearn.common.api.ApiResponse
 import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team.TeamId
 import com.jipsa.balearn.domain.team.TeamService
 import com.jipsa.balearn.domain.user.User
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
@@ -35,5 +34,13 @@ class TeamApi(
                 )
             )
         )
+    }
+
+    @GetMapping("/{teamId}")
+    fun readTeam(
+        @PathVariable teamId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<TeamResponse> {
+        return ApiResponse.success(teamService.readTeam(TeamId(teamId), user.id))
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamCreateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamCreateRequest.kt
@@ -1,0 +1,10 @@
+package com.jipsa.balearn.api.team.dto
+
+import com.jipsa.balearn.domain.team_goal.TeamGoalInfo
+
+data class TeamCreateRequest(
+    val name: String,
+    val description: String,
+    val goals: List<TeamGoalInfo>? = null
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamCreateResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamCreateResponse.kt
@@ -1,0 +1,13 @@
+package com.jipsa.balearn.api.team.dto
+
+import com.jipsa.balearn.domain.team.Team
+
+data class TeamCreateResponse(
+    val teamId: Long
+) {
+    companion object {
+        fun from(team: Team): TeamCreateResponse {
+            return TeamCreateResponse(team.id.value)
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamReadResponse.kt
@@ -1,0 +1,30 @@
+package com.jipsa.balearn.api.team.dto
+
+import com.jipsa.balearn.domain.team.Team
+import java.time.LocalDateTime
+
+data class TeamReadResponse(
+    val id: Long,
+    val name: String,
+    val description: String,
+    val imgUrl: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: Long?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: Long?
+) {
+    companion object {
+        fun from(team: Team): TeamReadResponse {
+            return TeamReadResponse(
+                id = team.id.value,
+                name = team.teamInfo.name,
+                description = team.teamInfo.description,
+                imgUrl = team.teamInfo.teamImageUrl,
+                createdAt = team.createdAt,
+                createdBy = team.createdBy?.value,
+                modifiedAt = team.modifiedAt,
+                modifiedBy = team.modifiedBy?.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamResponse.kt
@@ -1,0 +1,15 @@
+package com.jipsa.balearn.api.team.dto
+
+import com.jipsa.balearn.api.notice.dto.NoticeReadResponse
+import com.jipsa.balearn.api.schedule.dto.ScheduleReadResponse
+import com.jipsa.balearn.api.team_goal.dto.TeamGoalReadResponse
+import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
+
+data class TeamResponse(
+    val team: TeamReadResponse,
+    val notice: NoticeReadResponse?,
+    val goal: List<TeamGoalReadResponse>,
+    val teamUser: List<TeamUserReadResponse>,
+    val weeklySchedule: List<ScheduleReadResponse>
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team_goal/dto/TeamGoalReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_goal/dto/TeamGoalReadResponse.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.api.team_goal.dto
+
+import com.jipsa.balearn.domain.team_goal.TeamGoal
+import java.time.LocalDateTime
+
+data class TeamGoalReadResponse(
+    val id: Long,
+    val detail: String,
+    val color: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: Long?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: Long?
+) {
+    companion object {
+        fun from(teamGoal: TeamGoal): TeamGoalReadResponse {
+            return TeamGoalReadResponse(
+                id = teamGoal.id.value,
+                detail = teamGoal.teamGoalInfo.detail,
+                color = teamGoal.teamGoalInfo.color,
+                createdAt = teamGoal.createdAt,
+                createdBy = teamGoal.createdBy?.value,
+                modifiedAt = teamGoal.modifiedAt,
+                modifiedBy = teamGoal.modifiedBy?.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team_user/dto/TeamUserReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_user/dto/TeamUserReadResponse.kt
@@ -1,0 +1,29 @@
+package com.jipsa.balearn.api.team_user.dto
+
+import com.jipsa.balearn.domain.team_user.TeamUser
+import com.jipsa.balearn.domain.team_user.TeamUserRole
+import java.time.LocalDateTime
+
+data class TeamUserReadResponse(
+    val id: Long,
+    val userId: Long,
+    val role: TeamUserRole,
+    val nickname: String,
+    val imgUrl: String,
+    val createdAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(teamUser: TeamUser): TeamUserReadResponse {
+            return TeamUserReadResponse(
+                id = teamUser.id.value,
+                userId = teamUser.user.id.value,
+                role = teamUser.profile.role,
+                nickname = teamUser.profile.nickname,
+                imgUrl = teamUser.profile.profileImageUrl,
+                createdAt = teamUser.createdAt,
+                modifiedAt = teamUser.modifiedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/common/dto/File.kt
+++ b/src/main/kotlin/com/jipsa/balearn/common/dto/File.kt
@@ -1,8 +1,17 @@
 package com.jipsa.balearn.common.dto
 
+import org.springframework.web.multipart.MultipartFile
+
 data class File(
     val contentType: String,
     val bytes: ByteArray,
     val originalFilename: String?,
     val size: Long
-)
+) {
+    companion object {
+        fun from(file: MultipartFile): File {
+            val contentType = file.contentType ?: throw IllegalArgumentException("File content type is null")
+            return File(contentType, file.bytes, file.originalFilename, file.size)
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/common/dto/File.kt
+++ b/src/main/kotlin/com/jipsa/balearn/common/dto/File.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.common.dto
+
+data class File(
+    val contentType: String,
+    val bytes: ByteArray,
+    val originalFilename: String?,
+    val size: Long
+)

--- a/src/main/kotlin/com/jipsa/balearn/database/config/JpaAuditingConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/config/JpaAuditingConfig.kt
@@ -1,8 +1,37 @@
 package com.jipsa.balearn.database.config
 
+import com.jipsa.balearn.domain.user.UserReader
+import com.jipsa.balearn.infra.oauth2.CustomOAuth2UserDetail
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.util.*
 
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 @Configuration
 class JpaAuditingConfig
+
+@Component
+class AuditorAwareImpl(
+    private val userReader: UserReader // User 정보 로드에 필요한 의존성 주입
+) : AuditorAware<Long> {
+
+    override fun getCurrentAuditor(): Optional<Long> {
+        val authentication = SecurityContextHolder.getContext().authentication
+
+        if (authentication != null && authentication.isAuthenticated) {
+            // CustomOAuth2UserDetail에서 사용자 이메일 가져오기
+            val principal = authentication.principal
+            if (principal is CustomOAuth2UserDetail) {
+                val user = principal.getUser()
+                return Optional.of(
+                    user?.id?.value ?: userReader.readByEmail(principal.getEmail()).id.value
+                )
+            }
+        }
+
+        return Optional.empty() // 인증되지 않은 경우 처리
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
 import com.jipsa.balearn.domain.user.UserId
+import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedBy
@@ -14,7 +15,8 @@ import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
-
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity : BaseTimeEntity() {
     @CreatedBy
     var createdBy: Long? = null

--- a/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
@@ -4,16 +4,25 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.jipsa.balearn.domain.user.UserId
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 
 abstract class BaseEntity : BaseTimeEntity() {
+    @CreatedBy
+    var createdBy: Long? = null
+        protected set
 
+    @LastModifiedBy
+    var modifiedBy: Long? = null
+        protected set
 }
 
 @MappedSuperclass

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntity.kt
@@ -1,0 +1,37 @@
+package com.jipsa.balearn.database.learning_file.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.learning_file.LearningFIleId
+import com.jipsa.balearn.domain.learning_file.LearningFIleInfo
+import com.jipsa.balearn.domain.learning_file.LearningFile
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "learning_files")
+class LearningFileEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    val team: TeamEntity,
+
+    @Embedded
+    val learningFIleInfo: LearningFIleInfoVO
+) : BaseEntity() {
+    fun toDomain() = LearningFile(
+        id = LearningFIleId(id),
+        team = team.toDomain(),
+        _learningFileInfo = learningFIleInfo.toDomain()
+    )
+
+    companion object {
+        fun from(learningFile: LearningFile) = LearningFileEntity(
+            id = learningFile.id.value,
+            team = TeamEntity.from(learningFile.team),
+            learningFIleInfo = LearningFIleInfoVO.from(learningFile.learningFileInfo)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntityVO.kt
@@ -1,0 +1,40 @@
+package com.jipsa.balearn.database.learning_file.entity
+
+import com.jipsa.balearn.domain.learning_file.LearningFIleInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class LearningFIleInfoVO(
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val fileUrl: String,
+
+    @Column(nullable = false)
+    val size: Double,
+
+    @Column(nullable = false)
+    val type: String
+) {
+    fun toDomain(): LearningFIleInfo {
+        return LearningFIleInfo(
+            name = name,
+            fileUrl = fileUrl,
+            size = size,
+            type = type
+        )
+    }
+
+    companion object {
+        fun from(learningFIleInfo: LearningFIleInfo): LearningFIleInfoVO {
+            return LearningFIleInfoVO(
+                name = learningFIleInfo.name,
+                fileUrl = learningFIleInfo.fileUrl,
+                size = learningFIleInfo.size,
+                type = learningFIleInfo.type
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission/entity/MissionEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission/entity/MissionEntity.kt
@@ -1,0 +1,43 @@
+package com.jipsa.balearn.database.mission.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.database.schedule.entity.ScheduleEntity
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.mission.Mission
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission.MissionInfo
+import com.jipsa.balearn.domain.schedule.Schedule
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "missions")
+class MissionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    val schedule: ScheduleEntity,
+
+    @Embedded
+    val missionInfo: MissionInfoVO
+) : BaseEntity() {
+    fun toDomain(): Mission {
+        return Mission(
+            id = MissionId(id),
+            schedule = schedule.toDomain(),
+            _missionInfo = missionInfo.toDomain()
+        )
+    }
+
+    companion object {
+        fun from(mission: Mission): MissionEntity {
+            return MissionEntity(
+                id = mission.id.value,
+                schedule = ScheduleEntity.from(mission.schedule),
+                missionInfo = MissionInfoVO.from(mission.missionInfo)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission/entity/MissionEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission/entity/MissionEntityVO.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.database.mission.entity
+
+import com.jipsa.balearn.domain.mission.MissionInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class MissionInfoVO(
+    @Column(nullable = false)
+    val detail: String
+) {
+    fun toDomain() = MissionInfo(detail)
+
+    companion object {
+        fun from(missionInfo: MissionInfo) = MissionInfoVO(missionInfo.detail)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission/repository/MissionJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission/repository/MissionJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.database.mission.repository
+
+import com.jipsa.balearn.database.mission.entity.MissionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MissionJpaRepository : JpaRepository<MissionEntity, Long> {
+    fun findBySchedule_Id(scheduleId: Long): List<MissionEntity>
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission/repository/MissionRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission/repository/MissionRepositoryAdaptor.kt
@@ -1,0 +1,35 @@
+package com.jipsa.balearn.database.mission.repository
+
+import com.jipsa.balearn.database.mission.entity.MissionEntity
+import com.jipsa.balearn.domain.mission.Mission
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission.MissionRepository
+import com.jipsa.balearn.domain.schedule.ScheduleId
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class MissionRepositoryAdaptor(
+    private val missionJpaRepository: MissionJpaRepository
+) : MissionRepository {
+    override fun save(mission: Mission): Mission {
+        return missionJpaRepository.save(MissionEntity.from(mission)).toDomain()
+    }
+
+    override fun findById(missionId: MissionId): Mission? {
+        return missionJpaRepository.findById(missionId.value).getOrNull()?.toDomain()
+    }
+
+    override fun findByScheduleId(scheduleId: ScheduleId): List<Mission> {
+        return missionJpaRepository.findBySchedule_Id(scheduleId.value).map { it.toDomain() }
+    }
+
+    override fun deleteById(missionId: MissionId) {
+        missionJpaRepository.deleteById(missionId.value)
+    }
+
+    override fun delete(mission: Mission) {
+        missionJpaRepository.delete(MissionEntity.from(mission))
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission_clear/entity/MissionClearEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission_clear/entity/MissionClearEntity.kt
@@ -1,0 +1,24 @@
+package com.jipsa.balearn.database.mission_clear.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.domain.mission_clear.MissionClear
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "mission_clears")
+class MissionClearEntity(
+    @EmbeddedId
+    val missionClearId: MissionClearEntityId
+) : BaseEntity() {
+    fun toDomain() = MissionClear(
+        missionClearId = missionClearId.toDomain()
+    )
+
+    companion object {
+        fun from(missionClear: MissionClear) = MissionClearEntity(
+            missionClearId = MissionClearEntityId.from(missionClear.missionClearId)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission_clear/entity/MissionClearEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission_clear/entity/MissionClearEntityVO.kt
@@ -1,0 +1,26 @@
+package com.jipsa.balearn.database.mission_clear.entity
+
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission_clear.MissionClearId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+data class MissionClearEntityId(
+
+    @Column(name = "mission_id")
+    val missionId: MissionId,
+
+    @Column(name = "team_user_id")
+    val teamUserId: TeamUserId
+
+) : Serializable {
+    fun toDomain() = MissionClearId(missionId, teamUserId)
+
+    companion object {
+        fun from(missionClearId: MissionClearId) =
+            MissionClearEntityId(missionClearId.missionId, missionClearId.teamUserId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission_clear/repository/MissionClearJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission_clear/repository/MissionClearJpaRepository.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.database.mission_clear.repository
+
+import com.jipsa.balearn.database.mission_clear.entity.MissionClearEntity
+import com.jipsa.balearn.database.mission_clear.entity.MissionClearEntityId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MissionClearJpaRepository : JpaRepository<MissionClearEntity, MissionClearEntityId> {
+    fun existsMissionClearEntityByMissionClearId_MissionIdAndMissionClearId_TeamUserId(
+        missionId: Long,
+        teamUserId: Long
+    ): Boolean
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/mission_clear/repository/MissionClearRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/mission_clear/repository/MissionClearRepositoryAdaptor.kt
@@ -1,0 +1,48 @@
+package com.jipsa.balearn.database.mission_clear.repository
+
+import com.jipsa.balearn.database.mission_clear.entity.MissionClearEntity
+import com.jipsa.balearn.database.mission_clear.entity.MissionClearEntityId
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission_clear.MissionClear
+import com.jipsa.balearn.domain.mission_clear.MissionClearId
+import com.jipsa.balearn.domain.mission_clear.MissionClearRepository
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import org.springframework.stereotype.Repository
+
+@Repository
+class MissionClearRepositoryAdaptor(
+    private val missionClearJpaRepository: MissionClearJpaRepository
+) : MissionClearRepository {
+    override fun save(missionClear: MissionClear): MissionClear {
+        return missionClearJpaRepository.save(MissionClearEntity.from(missionClear)).toDomain()
+    }
+
+    override fun save(missionId: MissionId, teamUserId: TeamUserId): MissionClear {
+        return missionClearJpaRepository.save(
+            MissionClearEntity.from(
+                MissionClear(
+                    MissionClearId(
+                        missionId,
+                        teamUserId
+                    )
+                )
+            )
+        ).toDomain()
+    }
+
+    override fun existsById(missionClearId: MissionClearId): Boolean {
+        return missionClearJpaRepository.existsById(MissionClearEntityId.from(missionClearId))
+    }
+
+    override fun existsById(missionId: MissionId, teamUserId: TeamUserId): Boolean {
+        return missionClearJpaRepository.existsById(MissionClearEntityId(missionId, teamUserId))
+    }
+
+    override fun deleteById(missionClearId: MissionClearId) {
+        missionClearJpaRepository.deleteById(MissionClearEntityId.from(missionClearId))
+    }
+
+    override fun deleteById(missionId: MissionId, teamUserId: TeamUserId) {
+        missionClearJpaRepository.deleteById(MissionClearEntityId(missionId, teamUserId))
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/entity/NoticeEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/entity/NoticeEntity.kt
@@ -1,0 +1,42 @@
+package com.jipsa.balearn.database.notice.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.notice.Notice
+import com.jipsa.balearn.domain.notice.NoticeId
+import com.jipsa.balearn.domain.user.UserId
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "notices")
+class NoticeEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    val team: TeamEntity,
+
+    @Embedded
+    val noticeInfo: NoticeInfoVO,
+) : BaseEntity() {
+
+    fun toDomain() = Notice(
+        id = NoticeId(id),
+        team = team.toDomain(),
+        _noticeInfo = noticeInfo.toDomain(),
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
+        createdBy = createdBy?.let { UserId(it) },
+        modifiedBy = modifiedBy?.let { UserId(it) }
+    )
+
+    companion object {
+        fun from(notice: Notice) = NoticeEntity(
+            id = notice.id.value,
+            team = TeamEntity.from(notice.team),
+            noticeInfo = NoticeInfoVO.from(notice.noticeInfo)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/entity/NoticeEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/entity/NoticeEntityVO.kt
@@ -1,0 +1,26 @@
+package com.jipsa.balearn.database.notice.entity
+
+import com.jipsa.balearn.domain.notice.NoticeInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class NoticeInfoVO(
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(nullable = false)
+    val detail: String,
+) {
+    fun toDomain() = NoticeInfo(
+        title = title,
+        detail = detail
+    )
+
+    companion object {
+        fun from(noticeInfo: NoticeInfo) = NoticeInfoVO(
+            title = noticeInfo.title,
+            detail = noticeInfo.detail
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.database.notice.repository
+
+import com.jipsa.balearn.database.notice.entity.NoticeEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NoticeJpaRepository : JpaRepository<NoticeEntity, Long> {
+    fun findByTeam_Id(teamId: Long): List<NoticeEntity>
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeJpaRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface NoticeJpaRepository : JpaRepository<NoticeEntity, Long> {
     fun findByTeam_Id(teamId: Long): List<NoticeEntity>
+
+    fun findFirstByTeam_IdOrderByCreatedAtDesc(teamId: Long): NoticeEntity?
 }

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeRepositoryAdaptor.kt
@@ -24,6 +24,10 @@ class NoticeRepositoryAdaptor(
         return noticeJpaRepository.findByTeam_Id(teamId.value).map { it.toDomain() }
     }
 
+    override fun findFirstByTeamIdOrderByCreatedAtDesc(teamId: TeamId): Notice? {
+        return noticeJpaRepository.findFirstByTeam_IdOrderByCreatedAtDesc(teamId.value)?.toDomain()
+    }
+
     override fun delete(notice: Notice) {
         noticeJpaRepository.delete(NoticeEntity.from(notice))
     }

--- a/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/notice/repository/NoticeRepositoryAdaptor.kt
@@ -1,0 +1,34 @@
+package com.jipsa.balearn.database.notice.repository
+
+import com.jipsa.balearn.database.notice.entity.NoticeEntity
+import com.jipsa.balearn.domain.notice.Notice
+import com.jipsa.balearn.domain.notice.NoticeId
+import com.jipsa.balearn.domain.notice.NoticeRepository
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class NoticeRepositoryAdaptor(
+    private val noticeJpaRepository: NoticeJpaRepository
+) : NoticeRepository {
+    override fun save(notice: Notice): Notice {
+        return noticeJpaRepository.save(NoticeEntity.from(notice)).toDomain()
+    }
+
+    override fun findById(noticeId: NoticeId): Notice? {
+        return noticeJpaRepository.findById(noticeId.value).getOrNull()?.toDomain()
+    }
+
+    override fun findByTeamId(teamId: TeamId): List<Notice> {
+        return noticeJpaRepository.findByTeam_Id(teamId.value).map { it.toDomain() }
+    }
+
+    override fun delete(notice: Notice) {
+        noticeJpaRepository.delete(NoticeEntity.from(notice))
+    }
+
+    override fun deleteById(noticeId: NoticeId) {
+        noticeJpaRepository.deleteById(noticeId.value)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/schedule/entity/ScheduleEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/schedule/entity/ScheduleEntity.kt
@@ -1,0 +1,41 @@
+package com.jipsa.balearn.database.schedule.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.schedule.Schedule
+import com.jipsa.balearn.domain.schedule.ScheduleId
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "schedules")
+class ScheduleEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    val team: TeamEntity,
+
+    @Embedded
+    val scheduleInfo: ScheduleInfoVO
+) : BaseEntity() {
+
+    fun toDomain(): Schedule {
+        return Schedule(
+            id = ScheduleId(id),
+            team = team.toDomain(),
+            _scheduleInfo = scheduleInfo.toDomain()
+        )
+    }
+
+    companion object {
+        fun from(schedule: Schedule): ScheduleEntity {
+            return ScheduleEntity(
+                id = schedule.id.value,
+                team = TeamEntity.from(schedule.team),
+                scheduleInfo = ScheduleInfoVO.from(schedule.scheduleInfo)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/schedule/entity/ScheduleEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/schedule/entity/ScheduleEntityVO.kt
@@ -1,0 +1,32 @@
+package com.jipsa.balearn.database.schedule.entity
+
+import com.jipsa.balearn.domain.schedule.ScheduleInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.time.LocalDateTime
+
+@Embeddable
+data class ScheduleInfoVO(
+    @Column(nullable = false)
+    val time: LocalDateTime,
+
+    @Column(nullable = false)
+    val address: String,
+
+    @Column(nullable = false)
+    val topic: String
+) {
+    fun toDomain() = ScheduleInfo(
+        time = time,
+        address = address,
+        topic = topic
+    )
+
+    companion object {
+        fun from(scheduleInfo: ScheduleInfo) = ScheduleInfoVO(
+            time = scheduleInfo.time,
+            address = scheduleInfo.address,
+            topic = scheduleInfo.topic
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/schedule/repository/ScheduleJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/schedule/repository/ScheduleJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.jipsa.balearn.database.schedule.repository
+
+import com.jipsa.balearn.database.schedule.entity.ScheduleEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+interface ScheduleJpaRepository : JpaRepository<ScheduleEntity, Long> {
+    fun findByTeam_IdAndScheduleInfo_TimeBetween(
+        teamId: Long,
+        startTime: LocalDateTime,
+        endTime: LocalDateTime
+    ): List<ScheduleEntity>
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/schedule/repository/ScheduleRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/schedule/repository/ScheduleRepositoryAdaptor.kt
@@ -1,0 +1,40 @@
+package com.jipsa.balearn.database.schedule.repository
+
+import com.jipsa.balearn.database.schedule.entity.ScheduleEntity
+import com.jipsa.balearn.domain.schedule.Schedule
+import com.jipsa.balearn.domain.schedule.ScheduleId
+import com.jipsa.balearn.domain.schedule.ScheduleRepository
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class ScheduleRepositoryAdaptor(
+    private val scheduleJpaRepository: ScheduleJpaRepository
+) : ScheduleRepository {
+    override fun save(schedule: Schedule): Schedule {
+        return scheduleJpaRepository.save(ScheduleEntity.from(schedule)).toDomain()
+    }
+
+    override fun findById(scheduleId: ScheduleId): Schedule? {
+        return scheduleJpaRepository.findById(scheduleId.value).getOrNull()?.toDomain()
+    }
+
+    override fun findByStartDateAndEndDate(
+        teamId: TeamId,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<Schedule> {
+        return scheduleJpaRepository.findByTeam_IdAndScheduleInfo_TimeBetween(teamId.value, startDate, endDate)
+            .map { it.toDomain() }
+    }
+
+    override fun delete(schedule: Schedule) {
+        scheduleJpaRepository.delete(ScheduleEntity.from(schedule))
+    }
+
+    override fun deleteById(scheduleId: ScheduleId) {
+        scheduleJpaRepository.deleteById(scheduleId.value)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntity.kt
@@ -3,6 +3,7 @@ package com.jipsa.balearn.database.team.entity
 import com.jipsa.balearn.database.global.BaseEntity
 import com.jipsa.balearn.domain.team.Team
 import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.user.UserId
 import jakarta.persistence.*
 
 @Entity
@@ -18,7 +19,11 @@ class TeamEntity(
 ) : BaseEntity() {
     fun toDomain() = Team(
         id = TeamId(id),
-        _teamInfo = teamInfoVO.toDomain()
+        _teamInfo = teamInfoVO.toDomain(),
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
+        createdBy = createdBy?.let { UserId(it) },
+        modifiedBy = modifiedBy?.let { UserId(it) }
     )
 
     companion object {

--- a/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntity.kt
@@ -1,0 +1,30 @@
+package com.jipsa.balearn.database.team.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.team.TeamId
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "teams")
+class TeamEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Embedded
+    val teamInfoVO: TeamInfoVO
+
+) : BaseEntity() {
+    fun toDomain() = Team(
+        id = TeamId(id),
+        _teamInfo = teamInfoVO.toDomain()
+    )
+
+    companion object {
+        fun from(team: Team) = TeamEntity(
+            id = team.id.value,
+            teamInfoVO = TeamInfoVO.from(team.teamInfo)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntityVO.kt
@@ -1,0 +1,29 @@
+package com.jipsa.balearn.database.team.entity
+
+import com.jipsa.balearn.domain.team.TeamInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class TeamInfoVO(
+    @Column(nullable = false)
+    val name: String,
+    @Column(nullable = false)
+    val description: String,
+    @Column(nullable = false)
+    val teamImageUrl: String = "https://cdn-icons-png.flaticon.com/512/718/718339.png"
+) {
+    fun toDomain() = TeamInfo(
+        name = name,
+        description = description,
+        teamImageUrl = teamImageUrl
+    )
+
+    companion object {
+        fun from(teamInfo: TeamInfo) = TeamInfoVO(
+            name = teamInfo.name,
+            description = teamInfo.description,
+            teamImageUrl = teamInfo.teamImageUrl
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/entity/TeamEntityVO.kt
@@ -11,7 +11,7 @@ data class TeamInfoVO(
     @Column(nullable = false)
     val description: String,
     @Column(nullable = false)
-    val teamImageUrl: String = "https://cdn-icons-png.flaticon.com/512/718/718339.png"
+    val teamImageUrl: String = "https://cdn.balearn.o-r.kr/profile/default-team.png"
 ) {
     fun toDomain() = TeamInfo(
         name = name,

--- a/src/main/kotlin/com/jipsa/balearn/database/team/repository/TeamJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/repository/TeamJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.database.team.repository
+
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamJpaRepository : JpaRepository<TeamEntity, Long> {
+
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team/repository/TeamRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team/repository/TeamRepositoryAdaptor.kt
@@ -1,0 +1,29 @@
+package com.jipsa.balearn.database.team.repository
+
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team.TeamRepository
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class TeamRepositoryAdaptor(
+    private val teamJpaRepository: TeamJpaRepository
+) : TeamRepository {
+    override fun save(team: Team): Team {
+        return teamJpaRepository.save(TeamEntity.from(team)).toDomain()
+    }
+
+    override fun findById(teamId: TeamId): Team? {
+        return teamJpaRepository.findById(teamId.value).getOrNull()?.toDomain()
+    }
+
+    override fun delete(team: Team) {
+        teamJpaRepository.delete(TeamEntity.from(team))
+    }
+
+    override fun deleteById(teamId: TeamId) {
+        teamJpaRepository.deleteById(teamId.value)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntity.kt
@@ -1,0 +1,42 @@
+package com.jipsa.balearn.database.team_goal.entity
+
+import com.jipsa.balearn.database.global.BaseEntity
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.domain.team_goal.TeamGoal
+import com.jipsa.balearn.domain.team_goal.TeamGoalId
+import com.jipsa.balearn.domain.user.UserId
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "team_goals")
+class TeamGoalEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Embedded
+    val teamGoalInfoVO: TeamGoalInfoVO,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    val teamEntity: TeamEntity
+) : BaseEntity() {
+
+    fun toDomain() = TeamGoal(
+        id = TeamGoalId(id),
+        _teamGoalInfo = teamGoalInfoVO.toDomain(),
+        team = teamEntity.toDomain(),
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
+        createdBy = createdBy?.let { UserId(it) },
+        modifiedBy = modifiedBy?.let { UserId(it) }
+    )
+
+    companion object {
+        fun from(teamGoal: TeamGoal) = TeamGoalEntity(
+            id = teamGoal.id.value,
+            teamGoalInfoVO = TeamGoalInfoVO.from(teamGoal.teamGoalInfo),
+            teamEntity = TeamEntity.from(teamGoal.team)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntity.kt
@@ -19,13 +19,13 @@ class TeamGoalEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
-    val teamEntity: TeamEntity
+    val team: TeamEntity
 ) : BaseEntity() {
 
     fun toDomain() = TeamGoal(
         id = TeamGoalId(id),
         _teamGoalInfo = teamGoalInfoVO.toDomain(),
-        team = teamEntity.toDomain(),
+        team = team.toDomain(),
         createdAt = createdAt,
         modifiedAt = modifiedAt,
         createdBy = createdBy?.let { UserId(it) },
@@ -36,7 +36,7 @@ class TeamGoalEntity(
         fun from(teamGoal: TeamGoal) = TeamGoalEntity(
             id = teamGoal.id.value,
             teamGoalInfoVO = TeamGoalInfoVO.from(teamGoal.teamGoalInfo),
-            teamEntity = TeamEntity.from(teamGoal.team)
+            team = TeamEntity.from(teamGoal.team)
         )
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_goal/entity/TeamGoalEntityVO.kt
@@ -1,0 +1,26 @@
+package com.jipsa.balearn.database.team_goal.entity
+
+import com.jipsa.balearn.domain.team_goal.TeamGoal
+import com.jipsa.balearn.domain.team_goal.TeamGoalInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class TeamGoalInfoVO(
+    @Column(nullable = false)
+    val detail: String,
+    @Column(nullable = false)
+    val color: String
+) {
+    fun toDomain() = TeamGoalInfo(
+        detail = detail,
+        color = color
+    )
+
+    companion object {
+        fun from(teamGoalInfo: TeamGoalInfo) = TeamGoalInfoVO(
+            detail = teamGoalInfo.detail,
+            color = teamGoalInfo.color
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_goal/repository/TeamGoalJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_goal/repository/TeamGoalJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.database.team_goal.repository
+
+import com.jipsa.balearn.database.team_goal.entity.TeamGoalEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamGoalJpaRepository : JpaRepository<TeamGoalEntity, Long> {
+    fun findByTeam_Id(teamId: Long): List<TeamGoalEntity>
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_goal/repository/TeamGoalRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_goal/repository/TeamGoalRepositoryAdaptor.kt
@@ -1,0 +1,38 @@
+package com.jipsa.balearn.database.team_goal.repository
+
+import com.jipsa.balearn.database.team_goal.entity.TeamGoalEntity
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_goal.TeamGoal
+import com.jipsa.balearn.domain.team_goal.TeamGoalId
+import com.jipsa.balearn.domain.team_goal.TeamGoalRepository
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class TeamGoalRepositoryAdaptor(
+    private val teamGoalJpaRepository: TeamGoalJpaRepository
+) : TeamGoalRepository {
+    override fun save(teamGoal: TeamGoal): TeamGoal {
+        return teamGoalJpaRepository.save(TeamGoalEntity.from(teamGoal)).toDomain()
+    }
+
+    override fun saveAll(teamGoals: List<TeamGoal>): List<TeamGoal> {
+        return teamGoalJpaRepository.saveAll(teamGoals.map { TeamGoalEntity.from(it) }).map { it.toDomain() }
+    }
+
+    override fun findByTeamId(teamId: TeamId): List<TeamGoal> {
+        return teamGoalJpaRepository.findByTeam_Id(teamId.value).map { it.toDomain() }
+    }
+
+    override fun findById(teamGoalId: TeamGoalId): TeamGoal? {
+        return teamGoalJpaRepository.findById(teamGoalId.value).getOrNull()?.toDomain()
+    }
+
+    override fun delete(teamGoal: TeamGoal) {
+        teamGoalJpaRepository.delete(TeamGoalEntity.from(teamGoal))
+    }
+
+    override fun deleteById(teamGoalId: TeamGoalId) {
+        teamGoalJpaRepository.deleteById(teamGoalId.value)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntity.kt
@@ -1,0 +1,43 @@
+package com.jipsa.balearn.database.team_user.entity
+
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.database.user.entity.UserEntity
+import com.jipsa.balearn.domain.team_user.TeamUser
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.team_user.TeamUserProfile
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "team_users")
+class TeamUserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Embedded
+    val profile: TeamUserProfile,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: TeamEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: UserEntity
+) {
+    fun toDomain() = TeamUser(
+        id = TeamUserId(id),
+        _profile = profile,
+        team = team.toDomain(),
+        user = user.toDomain(),
+    )
+
+    companion object {
+        fun from(teamUser: TeamUser) = TeamUserEntity(
+            id = teamUser.id.value,
+            profile = teamUser.profile,
+            team = TeamEntity.from(teamUser.team),
+            user = UserEntity.from(teamUser.user)
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntity.kt
@@ -1,5 +1,6 @@
 package com.jipsa.balearn.database.team_user.entity
 
+import com.jipsa.balearn.database.global.BaseTimeEntity
 import com.jipsa.balearn.database.team.entity.TeamEntity
 import com.jipsa.balearn.database.user.entity.UserEntity
 import com.jipsa.balearn.domain.team_user.TeamUser
@@ -24,12 +25,14 @@ class TeamUserEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     val user: UserEntity
-) {
+) : BaseTimeEntity() {
     fun toDomain() = TeamUser(
         id = TeamUserId(id),
         _profile = profile,
         team = team.toDomain(),
         user = user.toDomain(),
+        createdAt = createdAt,
+        modifiedAt = modifiedAt
     )
 
     companion object {

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/entity/TeamUserEntityVO.kt
@@ -1,0 +1,33 @@
+package com.jipsa.balearn.database.team_user.entity
+
+import com.jipsa.balearn.domain.team_user.TeamUserProfile
+import com.jipsa.balearn.domain.team_user.TeamUserRole
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Embeddable
+data class TeamUserProfileVO(
+    @Column(nullable = false)
+    val nickname: String,
+    @Column(nullable = false)
+    val profileImageUrl: String,
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val role: TeamUserRole
+) {
+    fun toDomain() = TeamUserProfile(
+        nickname = nickname,
+        profileImageUrl = profileImageUrl,
+        role = role
+    )
+
+    companion object {
+        fun from(teamUserProfile: TeamUserProfile) = TeamUserProfile(
+            nickname = teamUserProfile.nickname,
+            profileImageUrl = teamUserProfile.profileImageUrl,
+            role = teamUserProfile.role
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserJpaRepository.kt
@@ -11,6 +11,8 @@ interface TeamUserJpaRepository : JpaRepository<TeamUserEntity, Long> {
 
     fun findByTeam_IdAndUser_Id(teamId: Long, userId: Long): TeamUserEntity?
 
+    fun existsByTeam_IdAndUser_Id(teamId: Long, userId: Long): Boolean
+
     fun deleteByTeam_Id(teamId: Long)
 
     fun deleteByUser_Id(userId: Long)

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserJpaRepository.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.database.team_user.repository
+
+import com.jipsa.balearn.database.team_user.entity.TeamUserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamUserJpaRepository : JpaRepository<TeamUserEntity, Long> {
+
+    fun findByTeam_Id(teamId: Long): List<TeamUserEntity>
+
+    fun findByUser_Id(userId: Long): List<TeamUserEntity>
+
+    fun findByTeam_IdAndUser_Id(teamId: Long, userId: Long): TeamUserEntity?
+
+    fun deleteByTeam_Id(teamId: Long)
+
+    fun deleteByUser_Id(userId: Long)
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserRepositoryAdaptor.kt
@@ -41,6 +41,10 @@ class TeamUserRepositoryAdaptor(
         return teamUserJpaRepository.findByTeam_IdAndUser_Id(teamId.value, userId.value)?.toDomain()
     }
 
+    override fun existsByTeamIdAndUserId(teamId: TeamId, userId: UserId): Boolean {
+        return teamUserJpaRepository.existsByTeam_IdAndUser_Id(teamId.value, userId.value)
+    }
+
     override fun delete(teamUser: TeamUser) {
         teamUserJpaRepository.delete(TeamUserEntity.from(teamUser))
     }

--- a/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/team_user/repository/TeamUserRepositoryAdaptor.kt
@@ -1,0 +1,59 @@
+package com.jipsa.balearn.database.team_user.repository
+
+import com.jipsa.balearn.database.team.entity.TeamEntity
+import com.jipsa.balearn.database.team_user.entity.TeamUserEntity
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team.TeamInfo
+import com.jipsa.balearn.domain.team_user.TeamUser
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.team_user.TeamUserRepository
+import com.jipsa.balearn.domain.user.UserId
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class TeamUserRepositoryAdaptor(
+    private val teamUserJpaRepository: TeamUserJpaRepository
+) : TeamUserRepository {
+    override fun save(teamUser: TeamUser): TeamUser {
+        return teamUserJpaRepository.save(TeamUserEntity.from(teamUser)).toDomain()
+    }
+
+    override fun saveAll(teamUsers: List<TeamUser>): List<TeamUser> {
+        return teamUserJpaRepository.saveAll(teamUsers.map { TeamUserEntity.from(it) }).map { it.toDomain() }
+    }
+
+    override fun findByTeamId(teamId: TeamId): List<TeamUser> {
+        return teamUserJpaRepository.findByTeam_Id(teamId.value).map { it.toDomain() }
+    }
+
+    override fun findByUserId(userId: UserId): List<TeamUser> {
+        return teamUserJpaRepository.findByUser_Id(userId.value).map { it.toDomain() }
+    }
+
+    override fun findById(teamUserId: TeamUserId): TeamUser? {
+        return teamUserJpaRepository.findById(teamUserId.value).getOrNull()?.toDomain()
+    }
+
+    override fun findByTeamIdAndUserId(teamId: TeamId, userId: UserId): TeamUser? {
+        return teamUserJpaRepository.findByTeam_IdAndUser_Id(teamId.value, userId.value)?.toDomain()
+    }
+
+    override fun delete(teamUser: TeamUser) {
+        teamUserJpaRepository.delete(TeamUserEntity.from(teamUser))
+    }
+
+    override fun deleteByTeamId(teamId: TeamId) {
+        teamUserJpaRepository.deleteByTeam_Id(teamId.value)
+    }
+
+    override fun deleteByUserId(userId: UserId) {
+        teamUserJpaRepository.deleteByUser_Id(userId.value)
+    }
+
+    override fun deleteById(teamUserId: TeamUserId) {
+        teamUserJpaRepository.deleteById(teamUserId.value)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/user/entity/UserEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/user/entity/UserEntityVO.kt
@@ -43,7 +43,7 @@ data class UserProfileVO(
     val phoneNumber: String?,
 
     @Column(nullable = false)
-    val profileImageUrl: String,
+    val profileImageUrl: String = "https://blog.kakaocdn.net/dn/bfZZQd/btrua3HciZ9/jSnHklZw9ekuzV8YGLZ9zK/%EC%B9%B4%ED%86%A1%20%EA%B8%B0%EB%B3%B8%ED%94%84%EB%A1%9C%ED%95%84%20%EC%82%AC%EC%A7%84%28%EC%97%B0%EC%B4%88%EB%A1%9Dver%29.jpg?attach=1&knm=img.jpg",
 ) {
     fun toDomain() = UserProfile(
         name = name,

--- a/src/main/kotlin/com/jipsa/balearn/database/user/entity/UserEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/user/entity/UserEntityVO.kt
@@ -43,7 +43,7 @@ data class UserProfileVO(
     val phoneNumber: String?,
 
     @Column(nullable = false)
-    val profileImageUrl: String = "https://blog.kakaocdn.net/dn/bfZZQd/btrua3HciZ9/jSnHklZw9ekuzV8YGLZ9zK/%EC%B9%B4%ED%86%A1%20%EA%B8%B0%EB%B3%B8%ED%94%84%EB%A1%9C%ED%95%84%20%EC%82%AC%EC%A7%84%28%EC%97%B0%EC%B4%88%EB%A1%9Dver%29.jpg?attach=1&knm=img.jpg",
+    val profileImageUrl: String = "https://cdn.balearn.o-r.kr/profile/default-user.jpg",
 ) {
     fun toDomain() = UserProfile(
         name = name,

--- a/src/main/kotlin/com/jipsa/balearn/database/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/user/repository/UserJpaRepository.kt
@@ -3,7 +3,7 @@ package com.jipsa.balearn.database.user.repository
 import com.jipsa.balearn.database.user.entity.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserJPARepository : JpaRepository<UserEntity, Long> {
+interface UserJpaRepository : JpaRepository<UserEntity, Long> {
     fun findByUserProfile_Email(email: String): UserEntity?
     fun findByUserProfile_PhoneNumber(name: String): UserEntity?
 }

--- a/src/main/kotlin/com/jipsa/balearn/database/user/repository/UserRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/user/repository/UserRepositoryAdaptor.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.optionals.getOrNull
 
 @Repository
 class UserRepositoryAdaptor(
-    private val userJPARepository: UserJPARepository
+    private val userJPARepository: UserJpaRepository
 ) : UserRepository {
     override fun save(user: User): User {
         return userJPARepository.save(UserEntity.from(user)).toDomain()

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFile.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFile.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.domain.learning_file
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class LearningFile(
+    val id: LearningFIleId = LearningFIleId(),
+    val team: Team,
+    private var _learningFileInfo: LearningFIleInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val learningFileInfo: LearningFIleInfo
+        get() = _learningFileInfo
+
+    fun updateLearningFileInfo(learningFileInfo: LearningFIleInfo) {
+        _learningFileInfo = learningFileInfo
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileVO.kt
@@ -1,0 +1,11 @@
+package com.jipsa.balearn.domain.learning_file
+
+@JvmInline
+value class LearningFIleId(val value: Long = 0)
+
+data class LearningFIleInfo(
+    val name: String,
+    val fileUrl: String,
+    val size: Double,
+    val type: String
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/Mission.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/Mission.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.domain.mission
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.schedule.Schedule
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class Mission(
+    val id: MissionId = MissionId(),
+    val schedule: Schedule,
+    private var _missionInfo: MissionInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val missionInfo: MissionInfo
+        get() = _missionInfo
+
+    fun updateMissionInfo(missionInfo: MissionInfo) {
+        _missionInfo = missionInfo
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionReader.kt
@@ -1,0 +1,18 @@
+package com.jipsa.balearn.domain.mission
+
+import com.jipsa.balearn.domain.notice.exception.CustomMissionException
+import com.jipsa.balearn.domain.schedule.ScheduleId
+import org.springframework.stereotype.Component
+
+@Component
+class MissionReader(
+    private val missionRepository: MissionRepository
+) {
+    fun read(missionId: MissionId): Mission {
+        return missionRepository.findById(missionId) ?: throw CustomMissionException.MissionNotFoundException
+    }
+
+    fun readBy(scheduleId: ScheduleId): List<Mission> {
+        return missionRepository.findByScheduleId(scheduleId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionRepository.kt
@@ -1,0 +1,11 @@
+package com.jipsa.balearn.domain.mission
+
+import com.jipsa.balearn.domain.schedule.ScheduleId
+
+interface MissionRepository {
+    fun save(mission: Mission): Mission
+    fun findById(missionId: MissionId): Mission?
+    fun findByScheduleId(scheduleId: ScheduleId): List<Mission>
+    fun deleteById(missionId: MissionId)
+    fun delete(mission: Mission)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/MissionVO.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.domain.mission
+
+@JvmInline
+value class MissionId(val value: Long = 0)
+
+data class MissionInfo(
+    val detail: String
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/exception/CustomMissionException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/exception/CustomMissionException.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomMissionException(errorCode: MissionErrorCode) : CustomException(errorCode) {
+    data object MissionNotFoundException :
+        CustomMissionException(MissionErrorCode.MISSION_NOT_FOUND) {
+        private fun readResolve(): Any = MissionNotFoundException
+
+        val EXCEPTION: CustomMissionException = MissionNotFoundException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission/exception/MissionErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission/exception/MissionErrorCode.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class MissionErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    MISSION_NOT_FOUND(404, "M001", "해당 미션을 찾지 못했습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClear.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClear.kt
@@ -1,0 +1,21 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class MissionClear(
+    val missionClearId: MissionClearId,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearRepository.kt
@@ -1,0 +1,13 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+
+interface MissionClearRepository {
+    fun save(missionClear: MissionClear): MissionClear
+    fun save(missionId: MissionId, teamUserId: TeamUserId): MissionClear
+    fun existsById(missionClearId: MissionClearId): Boolean
+    fun existsById(missionId: MissionId, teamUserId: TeamUserId): Boolean
+    fun deleteById(missionClearId: MissionClearId)
+    fun deleteById(missionId: MissionId, teamUserId: TeamUserId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearVO.kt
@@ -1,0 +1,10 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+
+
+data class MissionClearId(
+    val missionId: MissionId,
+    val teamUserId: TeamUserId
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/Notice.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/Notice.kt
@@ -1,0 +1,32 @@
+package com.jipsa.balearn.domain.notice
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class Notice(
+    val id: NoticeId,
+    val team: Team,
+    private var _noticeInfo: NoticeInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val noticeInfo: NoticeInfo
+        get() = _noticeInfo
+
+    fun updateNoticeInfo(noticeInfo: NoticeInfo) {
+        this._noticeInfo = noticeInfo
+    }
+
+    fun isOwner(userId: UserId) {
+        require(this.createdBy == userId) { "작성자만 가능합니다." }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/Notice.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/Notice.kt
@@ -6,7 +6,7 @@ import com.jipsa.balearn.domain.user.UserId
 import java.time.LocalDateTime
 
 class Notice(
-    val id: NoticeId,
+    val id: NoticeId = NoticeId(),
     val team: Team,
     private var _noticeInfo: NoticeInfo,
     createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeReader.kt
@@ -1,0 +1,18 @@
+package com.jipsa.balearn.domain.notice
+
+import com.jipsa.balearn.domain.notice.exception.CustomNoticeException
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.stereotype.Component
+
+@Component
+class NoticeReader(
+    private val noticeRepository: NoticeRepository
+) {
+    fun read(noticeId: NoticeId): Notice {
+        return noticeRepository.findById(noticeId) ?: throw CustomNoticeException.NoticeNotFoundException
+    }
+
+    fun readFirstBy(teamId: TeamId): Notice? {
+        return noticeRepository.findFirstByTeamIdOrderByCreatedAtDesc(teamId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeRepository.kt
@@ -1,0 +1,11 @@
+package com.jipsa.balearn.domain.notice
+
+import com.jipsa.balearn.domain.team.TeamId
+
+interface NoticeRepository {
+    fun save(notice: Notice): Notice
+    fun findById(noticeId: NoticeId): Notice?
+    fun findByTeamId(teamId: TeamId): List<Notice>
+    fun delete(notice: Notice)
+    fun deleteById(noticeId: NoticeId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeRepository.kt
@@ -8,4 +8,5 @@ interface NoticeRepository {
     fun findByTeamId(teamId: TeamId): List<Notice>
     fun delete(notice: Notice)
     fun deleteById(noticeId: NoticeId)
+    fun findFirstByTeamIdOrderByCreatedAtDesc(teamId: TeamId): Notice?
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeVO.kt
@@ -1,0 +1,10 @@
+package com.jipsa.balearn.domain.notice
+
+
+@JvmInline
+value class NoticeId(val value: Long)
+
+data class NoticeInfo(
+    val title: String,
+    val detail: String,
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeVO.kt
@@ -2,7 +2,7 @@ package com.jipsa.balearn.domain.notice
 
 
 @JvmInline
-value class NoticeId(val value: Long)
+value class NoticeId(val value: Long = 0)
 
 data class NoticeInfo(
     val title: String,

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/exception/CustomNoticeException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/exception/CustomNoticeException.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomNoticeException(errorCode: NoticeErrorCode) : CustomException(errorCode) {
+    data object NoticeNotFoundException :
+        CustomNoticeException(NoticeErrorCode.NOTICE_NOT_FOUND) {
+        private fun readResolve(): Any = NoticeNotFoundException
+
+        val EXCEPTION: CustomNoticeException = NoticeNotFoundException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/exception/NoticeErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/exception/NoticeErrorCode.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class NoticeErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    NOTICE_NOT_FOUND(404, "N001", "해당 공지사항을 찾지 못했습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/Schedule.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/Schedule.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.domain.schedule
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class Schedule(
+    val id: ScheduleId = ScheduleId(),
+    val team: Team,
+    private var _scheduleInfo: ScheduleInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val scheduleInfo: ScheduleInfo
+        get() = _scheduleInfo
+
+    fun updateScheduleInfo(scheduleInfo: ScheduleInfo) {
+        _scheduleInfo = scheduleInfo
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleReader.kt
@@ -1,0 +1,33 @@
+package com.jipsa.balearn.domain.schedule
+
+import com.jipsa.balearn.domain.schedule.exception.CustomScheduleException
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.stereotype.Component
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.temporal.TemporalAdjusters
+
+@Component
+class ScheduleReader(
+    private val scheduleRepository: ScheduleRepository
+) {
+    fun read(scheduleId: ScheduleId): Schedule {
+        return scheduleRepository.findById(scheduleId)
+            ?: throw CustomScheduleException.ScheduleNotFoundException
+    }
+
+    fun readWeeklyScheduleBy(teamId: TeamId): List<Schedule> {
+        val today = LocalDate.now()
+        val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).atStartOfDay()
+        val endOfWeek = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).atTime(LocalTime.MAX)
+        return scheduleRepository.findByStartDateAndEndDate(teamId, startOfWeek, endOfWeek)
+    }
+
+    fun readMonthlyScheduleBy(teamId: TeamId): List<Schedule> {
+        val today = LocalDate.now()
+        val startOfMonth = today.with(TemporalAdjusters.firstDayOfMonth()).atStartOfDay()
+        val endOfMonth = today.with(TemporalAdjusters.lastDayOfMonth()).atTime(LocalTime.MAX)
+        return scheduleRepository.findByStartDateAndEndDate(teamId, startOfMonth, endOfMonth)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleRepository.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.schedule
+
+import com.jipsa.balearn.domain.team.TeamId
+import java.time.LocalDateTime
+
+interface ScheduleRepository {
+    fun save(schedule: Schedule): Schedule
+    fun findById(scheduleId: ScheduleId): Schedule?
+    fun findByStartDateAndEndDate(teamId: TeamId, startDate: LocalDateTime, endDate: LocalDateTime): List<Schedule>
+    fun delete(schedule: Schedule)
+    fun deleteById(scheduleId: ScheduleId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleVO.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.schedule
+
+import java.time.LocalDateTime
+
+@JvmInline
+value class ScheduleId(val value: Long = 0)
+
+data class ScheduleInfo(
+    val time: LocalDateTime,
+    val address: String,
+    val topic: String
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/exception/CustomScheduleException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/exception/CustomScheduleException.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomScheduleException(errorCode: ScheduleErrorCode) : CustomException(errorCode) {
+    data object ScheduleNotFoundException :
+        CustomScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND) {
+        private fun readResolve(): Any = ScheduleNotFoundException
+
+        val EXCEPTION: CustomScheduleException = ScheduleNotFoundException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/exception/ScheduleErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/exception/ScheduleErrorCode.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class ScheduleErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    SCHEDULE_NOT_FOUND(404, "S001", "해당 일정을 찾지 못했습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/Team.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/Team.kt
@@ -5,7 +5,7 @@ import com.jipsa.balearn.domain.user.UserId
 import java.time.LocalDateTime
 
 class Team(
-    val id: TeamId,
+    val id: TeamId = TeamId(),
     private var _teamInfo: TeamInfo,
     createdAt: LocalDateTime? = null,
     modifiedAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/Team.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/Team.kt
@@ -1,0 +1,26 @@
+package com.jipsa.balearn.domain.team
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class Team(
+    val id: TeamId,
+    private var _teamInfo: TeamInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val teamInfo: TeamInfo
+        get() = _teamInfo
+
+    fun updateTeamInfo(teamInfo: TeamInfo) {
+        this._teamInfo = teamInfo
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamAppender.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.team
+
+import org.springframework.stereotype.Component
+
+@Component
+class TeamAppender(
+    private val teamRepository: TeamRepository
+) {
+    fun append(team: Team): Team {
+        return teamRepository.save(team)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamImageAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamImageAppender.kt
@@ -1,0 +1,14 @@
+package com.jipsa.balearn.domain.team
+
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.infra.gcs.GcsFileUploader
+import org.springframework.stereotype.Component
+
+@Component
+class TeamImageAppender(
+    private val gcsFileUploader: GcsFileUploader
+) {
+    fun append(image: File?): String? {
+        return image?.let { gcsFileUploader.uploadImageFile(it) }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamReader.kt
@@ -1,0 +1,7 @@
+package com.jipsa.balearn.domain.team
+
+import org.springframework.stereotype.Component
+
+@Component
+class TeamReader {
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamReader.kt
@@ -1,7 +1,14 @@
 package com.jipsa.balearn.domain.team
 
+import com.jipsa.balearn.domain.schedule.exception.CustomTeamException
 import org.springframework.stereotype.Component
 
 @Component
-class TeamReader {
+class TeamReader(
+    private val teamRepository: TeamRepository
+) {
+    fun read(teamId: TeamId): Team {
+        return teamRepository.findById(teamId)
+            ?: throw CustomTeamException.TeamNotFoundException
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamRepository.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.domain.team
+
+interface TeamRepository {
+    fun save(team: Team): Team
+    fun findById(teamId: TeamId): Team?
+    fun delete(team: Team)
+    fun deleteById(teamId: TeamId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
@@ -1,13 +1,25 @@
 package com.jipsa.balearn.domain.team
 
+import com.jipsa.balearn.api.notice.dto.NoticeReadResponse
+import com.jipsa.balearn.api.schedule.dto.ScheduleReadResponse
+import com.jipsa.balearn.api.team.dto.TeamReadResponse
+import com.jipsa.balearn.api.team.dto.TeamResponse
+import com.jipsa.balearn.api.team_goal.dto.TeamGoalReadResponse
+import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
 import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.mission.MissionReader
+import com.jipsa.balearn.domain.notice.NoticeReader
+import com.jipsa.balearn.domain.schedule.ScheduleReader
 import com.jipsa.balearn.domain.team_goal.TeamGoal
 import com.jipsa.balearn.domain.team_goal.TeamGoalAppender
 import com.jipsa.balearn.domain.team_goal.TeamGoalInfo
+import com.jipsa.balearn.domain.team_goal.TeamGoalReader
 import com.jipsa.balearn.domain.team_user.TeamUser
 import com.jipsa.balearn.domain.team_user.TeamUserAppender
+import com.jipsa.balearn.domain.team_user.TeamUserReader
 import com.jipsa.balearn.domain.team_user.TeamUserRole
 import com.jipsa.balearn.domain.user.User
+import com.jipsa.balearn.domain.user.UserId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +29,12 @@ class TeamService(
     private val teamReader: TeamReader,
     private val teamGoalAppender: TeamGoalAppender,
     private val teamUserAppender: TeamUserAppender,
-    private val teamImageAppender: TeamImageAppender
+    private val teamImageAppender: TeamImageAppender,
+    private val teamGoalReader: TeamGoalReader,
+    private val teamUserReader: TeamUserReader,
+    private val scheduleReader: ScheduleReader,
+    private val missionReader: MissionReader,
+    private val noticeReader: NoticeReader
 ) {
     @Transactional
     fun createTeam(name: String, description: String, goals: List<TeamGoalInfo>?, image: File?, user: User): Team {
@@ -57,5 +74,24 @@ class TeamService(
         )
 
         return team
+    }
+
+    @Transactional(readOnly = true)
+    fun readTeam(teamId: TeamId, userId: UserId): TeamResponse {
+        teamUserReader.validTeamUser(teamId, userId)
+        val team = TeamReadResponse.from(teamReader.read(teamId))
+        val goals = teamGoalReader.readBy(teamId).map { TeamGoalReadResponse.from(it) }
+        val users = teamUserReader.readBy(teamId).map { TeamUserReadResponse.from(it) }
+        val schedules = scheduleReader.readWeeklyScheduleBy(teamId)
+            .map { ScheduleReadResponse.from(it, missionReader.readBy(it.id)) }
+        val notice = noticeReader.readFirstBy(teamId)?.let { NoticeReadResponse.from(it) }
+
+        return TeamResponse(
+            team = team,
+            goal = goals,
+            teamUser = users,
+            weeklySchedule = schedules,
+            notice = notice
+        )
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
@@ -1,0 +1,61 @@
+package com.jipsa.balearn.domain.team
+
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team_goal.TeamGoal
+import com.jipsa.balearn.domain.team_goal.TeamGoalAppender
+import com.jipsa.balearn.domain.team_goal.TeamGoalInfo
+import com.jipsa.balearn.domain.team_user.TeamUser
+import com.jipsa.balearn.domain.team_user.TeamUserAppender
+import com.jipsa.balearn.domain.team_user.TeamUserRole
+import com.jipsa.balearn.domain.user.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TeamService(
+    private val teamAppender: TeamAppender,
+    private val teamReader: TeamReader,
+    private val teamGoalAppender: TeamGoalAppender,
+    private val teamUserAppender: TeamUserAppender,
+    private val teamImageAppender: TeamImageAppender
+) {
+    @Transactional
+    fun createTeam(name: String, description: String, goals: List<TeamGoalInfo>?, image: File?, user: User): Team {
+
+        val teamInfo = teamImageAppender.append(image)?.let {
+            TeamInfo(
+                name = name,
+                description = description,
+                teamImageUrl = it
+            )
+        } ?: TeamInfo(
+            name = name,
+            description = description
+        )
+
+        val team = teamAppender.append(
+            Team(
+                _teamInfo = teamInfo
+            )
+        )
+
+        goals?.let { goalInfos ->
+            teamGoalAppender.appendAll(goalInfos.map {
+                TeamGoal(
+                    team = team,
+                    _teamGoalInfo = it
+                )
+            })
+        }
+
+        teamUserAppender.append(
+            TeamUser.from(
+                team = team,
+                user = user,
+                role = TeamUserRole.OWNER
+            )
+        )
+
+        return team
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
@@ -6,5 +6,5 @@ value class TeamId(val value: Long)
 data class TeamInfo(
     val name: String,
     val description: String,
-    val teamImageUrl: String
+    val teamImageUrl: String = "https://cdn.balearn.o-r.kr/profile/default-team.png"
 )

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
@@ -1,7 +1,7 @@
 package com.jipsa.balearn.domain.team
 
 @JvmInline
-value class TeamId(val value: Long)
+value class TeamId(val value: Long = 0)
 
 data class TeamInfo(
     val name: String,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamVO.kt
@@ -1,0 +1,10 @@
+package com.jipsa.balearn.domain.team
+
+@JvmInline
+value class TeamId(val value: Long)
+
+data class TeamInfo(
+    val name: String,
+    val description: String,
+    val teamImageUrl: String
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/exception/CustomTeamException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/exception/CustomTeamException.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomTeamException(errorCode: TeamErrorCode) : CustomException(errorCode) {
+    data object TeamNotFoundException :
+        CustomTeamException(TeamErrorCode.TEAM_NOT_FOUND) {
+        private fun readResolve(): Any = TeamNotFoundException
+
+        val EXCEPTION: CustomTeamException = TeamNotFoundException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/exception/TeamErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/exception/TeamErrorCode.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class TeamErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    TEAM_NOT_FOUND(404, "T001", "해당 모임을 찾지 못했습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoal.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoal.kt
@@ -6,7 +6,7 @@ import com.jipsa.balearn.domain.user.UserId
 import java.time.LocalDateTime
 
 class TeamGoal(
-    val id: TeamGoalId,
+    val id: TeamGoalId = TeamGoalId(),
     val team: Team,
     private var _teamGoalInfo: TeamGoalInfo,
     createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoal.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoal.kt
@@ -1,0 +1,28 @@
+package com.jipsa.balearn.domain.team_goal
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.user.UserId
+import java.time.LocalDateTime
+
+class TeamGoal(
+    val id: TeamGoalId,
+    val team: Team,
+    private var _teamGoalInfo: TeamGoalInfo,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+    createdBy: UserId? = null,
+    modifiedBy: UserId? = null
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    createdBy = createdBy,
+    modifiedBy = modifiedBy
+) {
+    val teamGoalInfo: TeamGoalInfo
+        get() = _teamGoalInfo
+
+    fun updateInfo(teamGoalInfo: TeamGoalInfo) {
+        this._teamGoalInfo = teamGoalInfo
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalAppender.kt
@@ -1,0 +1,16 @@
+package com.jipsa.balearn.domain.team_goal
+
+import org.springframework.stereotype.Component
+
+@Component
+class TeamGoalAppender(
+    private val teamGoalRepository: TeamGoalRepository
+) {
+    fun append(teamGoal: TeamGoal): TeamGoal {
+        return teamGoalRepository.save(teamGoal)
+    }
+
+    fun appendAll(teamGoals: List<TeamGoal>): List<TeamGoal> {
+        return teamGoalRepository.saveAll(teamGoals)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalReader.kt
@@ -1,0 +1,13 @@
+package com.jipsa.balearn.domain.team_goal
+
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.stereotype.Component
+
+@Component
+class TeamGoalReader(
+    private val teamGoalRepository: TeamGoalRepository
+) {
+    fun readBy(teamId: TeamId): List<TeamGoal> {
+        return teamGoalRepository.findByTeamId(teamId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalRepository.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.team_goal
+
+import com.jipsa.balearn.domain.team.TeamId
+
+interface TeamGoalRepository {
+    fun save(teamGoal: TeamGoal): TeamGoal
+    fun saveAll(teamGoals: List<TeamGoal>): List<TeamGoal>
+    fun findByTeamId(teamId: TeamId): List<TeamGoal>
+    fun findById(teamGoalId: TeamGoalId): TeamGoal?
+    fun delete(teamGoal: TeamGoal)
+    fun deleteById(teamGoalId: TeamGoalId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalVO.kt
@@ -1,0 +1,9 @@
+package com.jipsa.balearn.domain.team_goal
+
+@JvmInline
+value class TeamGoalId(val value: Long)
+
+data class TeamGoalInfo(
+    val detail: String,
+    val color: String
+)

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalVO.kt
@@ -1,7 +1,7 @@
 package com.jipsa.balearn.domain.team_goal
 
 @JvmInline
-value class TeamGoalId(val value: Long)
+value class TeamGoalId(val value: Long = 0)
 
 data class TeamGoalInfo(
     val detail: String,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
@@ -1,0 +1,45 @@
+package com.jipsa.balearn.domain.team_user
+
+import com.jipsa.balearn.domain.global.Base
+import com.jipsa.balearn.domain.team.Team
+import com.jipsa.balearn.domain.user.User
+import java.time.LocalDateTime
+
+class TeamUser(
+    val id: TeamUserId,
+    private var _profile: TeamUserProfile,
+    val team: Team,
+    val user: User,
+    createdAt: LocalDateTime? = null,
+    modifiedAt: LocalDateTime? = null,
+) : Base(
+    createdAt = createdAt,
+    modifiedAt = modifiedAt
+) {
+    val profile: TeamUserProfile
+        get() = _profile
+
+    fun changeRole(role: TeamUserRole) {
+        this._profile = TeamUserProfile(
+            nickname = this._profile.nickname,
+            profileImageUrl = this._profile.profileImageUrl,
+            role = role
+        )
+    }
+
+    fun updateProfile(nickname: String, profileImageUrl: String) {
+        this._profile = TeamUserProfile(
+            nickname = nickname,
+            profileImageUrl = profileImageUrl,
+            role = this._profile.role
+        )
+    }
+
+    fun isOwner() {
+        require(this._profile.role == TeamUserRole.OWNER) { "소유자만 가능합니다." }
+    }
+
+    fun isLeader() {
+        require(this._profile.role == TeamUserRole.LEADER) { "리더만 가능합니다." }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
@@ -6,7 +6,7 @@ import com.jipsa.balearn.domain.user.User
 import java.time.LocalDateTime
 
 class TeamUser(
-    val id: TeamUserId,
+    val id: TeamUserId = TeamUserId(),
     private var _profile: TeamUserProfile,
     val team: Team,
     val user: User,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
@@ -42,4 +42,19 @@ class TeamUser(
     fun isLeader() {
         require(this._profile.role == TeamUserRole.LEADER) { "리더만 가능합니다." }
     }
+
+    companion object {
+        fun from(team: Team, user: User, role: TeamUserRole): TeamUser {
+            return TeamUser(
+                id = TeamUserId(0),
+                _profile = TeamUserProfile(
+                    nickname = user.userProfile.name,
+                    profileImageUrl = user.userProfile.profileImageUrl,
+                    role = role
+                ),
+                team = team,
+                user = user
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserAppender.kt
@@ -1,5 +1,6 @@
 package com.jipsa.balearn.domain.team_user
 
+import com.jipsa.balearn.domain.team_user.exception.CustomTeamUserException
 import org.springframework.stereotype.Component
 
 @Component
@@ -7,10 +8,13 @@ class TeamUserAppender(
     private val teamUserRepository: TeamUserRepository
 ) {
     fun append(teamUser: TeamUser): TeamUser {
+        isExistTeamUser(teamUser)
         return teamUserRepository.save(teamUser)
     }
 
-    fun appendAll(teamUsers: List<TeamUser>): List<TeamUser> {
-        return teamUserRepository.saveAll(teamUsers)
+    private fun isExistTeamUser(teamUser: TeamUser) {
+        if (teamUserRepository.existsByTeamIdAndUserId(teamUser.team.id, teamUser.user.id)) {
+            throw CustomTeamUserException.TeamUserAlreadyExistException
+        }
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserAppender.kt
@@ -1,0 +1,16 @@
+package com.jipsa.balearn.domain.team_user
+
+import org.springframework.stereotype.Component
+
+@Component
+class TeamUserAppender(
+    private val teamUserRepository: TeamUserRepository
+) {
+    fun append(teamUser: TeamUser): TeamUser {
+        return teamUserRepository.save(teamUser)
+    }
+
+    fun appendAll(teamUsers: List<TeamUser>): List<TeamUser> {
+        return teamUserRepository.saveAll(teamUsers)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserReader.kt
@@ -1,0 +1,34 @@
+package com.jipsa.balearn.domain.team_user
+
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_user.exception.CustomTeamUserException
+import com.jipsa.balearn.domain.user.UserId
+import org.springframework.stereotype.Component
+
+@Component
+class TeamUserReader(
+    private val teamUserRepository: TeamUserRepository
+) {
+    fun read(teamUserId: TeamUserId): TeamUser {
+        return teamUserRepository.findById(teamUserId) ?: throw CustomTeamUserException.TeamUserNotFoundException
+    }
+
+    fun readBy(teamId: TeamId): List<TeamUser> {
+        return teamUserRepository.findByTeamId(teamId)
+    }
+
+    fun readBy(userId: UserId): List<TeamUser> {
+        return teamUserRepository.findByUserId(userId)
+    }
+
+    fun readBy(teamId: TeamId, userId: UserId): TeamUser {
+        return teamUserRepository.findByTeamIdAndUserId(teamId, userId)
+            ?: throw CustomTeamUserException.TeamUserNotFoundException
+    }
+
+    fun validTeamUser(teamId: TeamId, userId: UserId) {
+        if (!teamUserRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw CustomTeamUserException.TeamUserNotValidException
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserRepository.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.team_user
+
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.user.UserId
+
+interface TeamUserRepository {
+    fun save(teamUser: TeamUser): TeamUser
+    fun saveAll(teamUsers: List<TeamUser>): List<TeamUser>
+    fun findByTeamId(teamId: TeamId): List<TeamUser>
+    fun findByUserId(userId: UserId): List<TeamUser>
+    fun findById(teamUserId: TeamUserId): TeamUser?
+    fun findByTeamIdAndUserId(teamId: TeamId, userId: UserId): TeamUser?
+    fun delete(teamUser: TeamUser)
+    fun deleteByTeamId(teamId: TeamId)
+    fun deleteByUserId(userId: UserId)
+    fun deleteById(teamUserId: TeamUserId)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserRepository.kt
@@ -14,4 +14,5 @@ interface TeamUserRepository {
     fun deleteByTeamId(teamId: TeamId)
     fun deleteByUserId(userId: UserId)
     fun deleteById(teamUserId: TeamUserId)
+    fun existsByTeamIdAndUserId(teamId: TeamId, userId: UserId): Boolean
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserVO.kt
@@ -1,8 +1,11 @@
 package com.jipsa.balearn.domain.team_user
 
-@JvmInline
-value class TeamUserId(val value: Long)
+import jakarta.persistence.Embeddable
 
+@JvmInline
+value class TeamUserId(val value: Long = 0)
+
+@Embeddable
 data class TeamUserProfile(
     val nickname: String,
     val profileImageUrl: String,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserVO.kt
@@ -1,0 +1,16 @@
+package com.jipsa.balearn.domain.team_user
+
+@JvmInline
+value class TeamUserId(val value: Long)
+
+data class TeamUserProfile(
+    val nickname: String,
+    val profileImageUrl: String,
+    val role: TeamUserRole
+)
+
+enum class TeamUserRole(name: String) {
+    OWNER("소유자"),
+    LEADER("리더"),
+    MEMBER("멤버")
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
@@ -1,0 +1,33 @@
+package com.jipsa.balearn.domain.team_user.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomTeamUserException(errorCode: TeamUserErrorCode) : CustomException(errorCode) {
+    data object TeamUserNotFoundException :
+        CustomTeamUserException(TeamUserErrorCode.TEAM_USER_NOT_FOUND) {
+        private fun readResolve(): Any = TeamUserNotFoundException
+
+        val EXCEPTION: CustomTeamUserException = TeamUserNotFoundException
+    }
+
+    data object TeamUserAlreadyExistException :
+        CustomTeamUserException(TeamUserErrorCode.TEAM_USER_ALREADY_EXIST) {
+        private fun readResolve(): Any = TeamUserAlreadyExistException
+
+        val EXCEPTION: CustomTeamUserException = TeamUserAlreadyExistException
+    }
+
+    data object TeamUserNotAuthorizedException :
+        CustomTeamUserException(TeamUserErrorCode.TEAM_USER_NOT_AUTHORIZED) {
+        private fun readResolve(): Any = TeamUserNotAuthorizedException
+
+        val EXCEPTION: CustomTeamUserException = TeamUserNotAuthorizedException
+    }
+
+    data object TeamUserNotValidException :
+        CustomTeamUserException(TeamUserErrorCode.TEAM_USER_NOT_VALID) {
+        private fun readResolve(): Any = TeamUserNotValidException
+
+        val EXCEPTION: CustomTeamUserException = TeamUserNotValidException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
@@ -1,0 +1,20 @@
+package com.jipsa.balearn.domain.team_user.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class TeamUserErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    TEAM_USER_NOT_FOUND(404, "TU001", "해당 모임원을 찾지 못했습니다."),
+    TEAM_USER_ALREADY_EXIST(409, "TU002", "이미 해당 모임원이 존재합니다."),
+    TEAM_USER_NOT_AUTHORIZED(403, "TU003", "해당 모임원에 대한 권한이 없습니다."),
+    TEAM_USER_NOT_VALID(403, "TU004", "해당 모임에 가입되어있지 않습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/User.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/User.kt
@@ -4,7 +4,7 @@ import com.jipsa.balearn.domain.global.Base
 import java.time.LocalDateTime
 
 class User(
-    val id: UserId,
+    val id: UserId = UserId(),
     private var _userProfile: UserProfile,
     val userProvider: UserProvider,
     createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserVO.kt
@@ -1,7 +1,7 @@
 package com.jipsa.balearn.domain.user
 
 @JvmInline
-value class UserId(val value: Long)
+value class UserId(val value: Long = 0)
 
 data class UserProfile(
     val name: String,

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserVO.kt
@@ -7,7 +7,7 @@ data class UserProfile(
     val name: String,
     val email: String,
     val phoneNumber: String? = null,
-    val profileImageUrl: String
+    val profileImageUrl: String = "https://cdn.balearn.o-r.kr/profile/default-user.jpg"
 )
 
 data class UserProvider(

--- a/src/main/kotlin/com/jipsa/balearn/infra/gcs/GcsConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/gcs/GcsConfig.kt
@@ -1,0 +1,37 @@
+package com.jipsa.balearn.infra.gcs
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.util.*
+
+@Configuration
+class GcsConfig(
+    @Value("\${spring.cloud.gcp.storage.credentials.encoded-key}")
+    private val gcpKey: String,
+    @Value("\${spring.cloud.gcp.storage.project-id}")
+    private val projectId: String
+) {
+
+    @Bean
+    @Throws(IOException::class)
+    fun storage(): Storage {
+        val credentials: GoogleCredentials = getDecodedCredentials(gcpKey)
+        return StorageOptions.newBuilder()
+            .setProjectId(projectId)
+            .setCredentials(credentials)
+            .build()
+            .service
+    }
+
+    @Throws(IOException::class)
+    private fun getDecodedCredentials(encodedKey: String?): GoogleCredentials {
+        val decodedKey = Base64.getDecoder().decode(encodedKey)
+        return GoogleCredentials.fromStream(ByteArrayInputStream(decodedKey))
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/infra/gcs/GcsFileUploader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/gcs/GcsFileUploader.kt
@@ -1,0 +1,108 @@
+package com.jipsa.balearn.infra.gcs
+
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import com.jipsa.balearn.common.dto.File
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class GcsFileUploader(
+    private val storage: Storage,
+    @Value("\${spring.cloud.gcp.storage.bucket}")
+    private val bucketName: String,
+    @Value("\${spring.cloud.gcp.storage.url}")
+    private val storagePath: String
+) {
+    fun uploadImageFile(file: File, directory: String = "profile"): String {
+        validateProfileImage(file)
+
+        val fileName = generateFileName(file.originalFilename)
+        val blobInfo = BlobInfo.newBuilder(bucketName, "$directory/$fileName")
+            .setContentType(file.contentType)
+            .build()
+
+        storage.create(blobInfo, file.bytes)
+
+        return "$storagePath$directory/$fileName"
+    }
+
+    fun uploadLearningMaterial(file: File, directory: String = "learn"): String {
+        validateLearningMaterial(file)
+
+        val fileName = generateFileName(file.originalFilename)
+        val blobInfo = BlobInfo.newBuilder(bucketName, "$directory/$fileName")
+            .setContentType(file.contentType)
+            .build()
+
+        storage.create(blobInfo, file.bytes)
+
+        return "$storagePath$directory/$fileName"
+    }
+
+    private fun generateFileName(originalFileName: String?): String {
+        val extension = originalFileName?.substringAfterLast('.', "")
+        return "${UUID.randomUUID()}.$extension"
+    }
+
+    private fun validateProfileImage(file: File) {
+        // 파일 크기 검증 (예: 5MB 제한)
+        if (file.size > 5 * 1024 * 1024) {
+            throw IllegalArgumentException("프로필 이미지는 5MB를 초과할 수 없습니다.")
+        }
+
+        // 파일 형식 검증
+        val allowedContentTypes = listOf("image/jpeg", "image/png", "image/gif")
+        if (!allowedContentTypes.contains(file.contentType)) {
+            throw IllegalArgumentException("지원하지 않는 이미지 형식입니다. (지원 형식: JPEG, PNG, GIF)")
+        }
+    }
+
+    private fun validateLearningMaterial(file: File) {
+        // 1. 파일 크기 검증 (예: 300MB 제한)
+        //    필요에 따라 제한 용량을 조정하세요.
+        if (file.size > 300 * 1024 * 1024) {
+            throw IllegalArgumentException("파일은 300MB를 초과할 수 없습니다.")
+        }
+
+        // 2. 지원 가능한 MIME 타입 목록
+        //    문서: PDF, MS 오피스 계열, 텍스트
+        //    이미지: JPEG, PNG, GIF
+        //    동영상: MP4, MOV, AVI 등
+        val allowedContentTypes = listOf(
+            // 문서
+            "application/pdf",
+            "application/msword", // .doc
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+            "application/vnd.ms-powerpoint", // .ppt
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation", // .pptx
+            "application/vnd.ms-excel", // .xls
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+            "text/plain", // .txt
+
+            // 이미지
+            "image/jpeg",
+            "image/png",
+            "image/gif",
+
+            // 동영상
+            "video/mp4",
+            "video/x-msvideo",    // .avi
+            "video/quicktime",    // .mov
+            "video/x-ms-wmv",     // .wmv
+            "video/webm"          // .webm
+        )
+
+        // 3. 파일 형식(MIME 타입) 검증
+        if (!allowedContentTypes.contains(file.contentType)) {
+            throw IllegalArgumentException(
+                """
+            지원하지 않는 파일 형식입니다. 
+            (지원 형식: PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, TXT, 
+              JPEG, PNG, GIF, MP4, AVI, MOV, WMV, WEBM 등)
+            """.trimIndent()
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,15 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+  cloud:
+    gcp:
+      storage:
+        url: https://${GCP_CDN_DOMAIN}/
+        credentials:
+          encoded-key: ${GCS_KEY}
+        project-id: ${GCP_PROJECT_ID}
+        bucket: ${BUCKET_NAME}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 3600000  # 1시간


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- team 추가 및 조회 관련 entity, repository, service, api 추가

### 팀 생성

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/43858235-6980-4040-bb43-a9a974da5d71" />

1. 유저 인증 정보와 data에 팀 데이터, image에 팀 프로필사진을 요청 ( 이 때, content-type은 form-data로 ) <br>
- data는 application/json <br>
- image는 multipartFile로 보내주기 ( image는 생략 가능, 생략하면 기본 프로필 사진으로 등록 ) <br>

2. request로 teamId 반환 <br>
### 팀 조회
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/8dd97f35-e4bf-482d-b6c5-0916f18852d3" />

- 노션 참고할 것
- **팀에 가입된 사람만 조회 가능**

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #6
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
궁금한 점은 질문주세요
