### PR TITLE
[Feat/#10] user 및 teamUser update

### DIFF
--- a/src/main/kotlin/com/jipsa/balearn/api/team_user/TeamUserApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_user/TeamUserApi.kt
@@ -1,0 +1,73 @@
+package com.jipsa.balearn.api.team_user
+
+import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
+import com.jipsa.balearn.api.team_user.dto.TeamUserUpdateRequest
+import com.jipsa.balearn.api.user.dto.UserResponse
+import com.jipsa.balearn.api.user.dto.UserUpdateRequest
+import com.jipsa.balearn.common.api.ApiResponse
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.team_user.TeamUserService
+import com.jipsa.balearn.domain.user.User
+import com.jipsa.balearn.domain.user.UserId
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/team")
+class TeamUserApi(
+    private val teamUserService: TeamUserService
+) {
+    @GetMapping("/{teamId}/me")
+    fun getMyTeamUser(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long
+    ): ApiResponse<TeamUserReadResponse> {
+        return ApiResponse.success(
+            TeamUserReadResponse.from(
+                teamUserService.readTeamUser(
+                    teamId = TeamId(teamId),
+                    userId = user.id
+                )
+            )
+        )
+    }
+
+    @GetMapping("/{teamId}/user/{teamUserId}")
+    fun getTeamUser(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long,
+        @PathVariable teamUserId: Long
+    ): ApiResponse<TeamUserReadResponse> {
+        return ApiResponse.success(
+            TeamUserReadResponse.from(
+                teamUserService.readTeamUser(
+                    teamId = TeamId(teamId),
+                    userId = user.id,
+                    teamUserId = TeamUserId(teamUserId)
+                )
+            )
+        )
+    }
+
+    @PutMapping("/{teamId}/me")
+    fun updateUser(
+        @RequestPart("data") request: TeamUserUpdateRequest,
+        @RequestPart("image", required = false) image: MultipartFile?,
+        @PathVariable teamId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<TeamUserReadResponse> {
+        return ApiResponse.success(
+            TeamUserReadResponse.from(
+                teamUserService.updateTeamUser(
+                    teamId = TeamId(teamId),
+                    userId = user.id,
+                    nickname = request.nickname,
+                    image = image?.let { File.from(it) }
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team_user/TeamUserApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_user/TeamUserApi.kt
@@ -9,6 +9,7 @@ import com.jipsa.balearn.common.api.ApiResponse
 import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.domain.team.TeamId
 import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.team_user.TeamUserRole
 import com.jipsa.balearn.domain.team_user.TeamUserService
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.domain.user.UserId
@@ -66,6 +67,55 @@ class TeamUserApi(
                     userId = user.id,
                     nickname = request.nickname,
                     image = image?.let { File.from(it) }
+                )
+            )
+        )
+    }
+
+    @PutMapping("/{teamId}/user/{teamUserId}")
+    fun changeUserRole(
+        @PathVariable teamId: Long,
+        @PathVariable teamUserId: Long,
+        @RequestParam role: String,
+        @CurrentUser user: User
+    ): ApiResponse<TeamUserReadResponse> {
+        val teamUserRole = when (role) {
+            "leader" -> TeamUserRole.LEADER
+            "member" -> TeamUserRole.MEMBER
+            else -> throw IllegalArgumentException("Invalid role")
+        }
+
+        return ApiResponse.success(
+            TeamUserReadResponse.from(
+                teamUserService.changeRole(
+                    teamId = TeamId(teamId),
+                    userId = user.id,
+                    teamUserId = TeamUserId(teamUserId),
+                    role = teamUserRole
+                )
+            )
+        )
+    }
+
+    @PutMapping("/{teamId}/user/{teamUserId}/owner")
+    fun changeOwner(
+        @PathVariable teamId: Long,
+        @PathVariable teamUserId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<TeamUserReadResponse> {
+        teamUserService.changeRole(
+            teamId = TeamId(teamId),
+            userId = user.id,
+            teamUserId = TeamUserId(teamUserId),
+            role = TeamUserRole.OWNER
+        )
+
+        return ApiResponse.success(
+            TeamUserReadResponse.from(
+                teamUserService.changeRole(
+                    teamId = TeamId(teamId),
+                    userId = user.id,
+                    role = TeamUserRole.LEADER
                 )
             )
         )

--- a/src/main/kotlin/com/jipsa/balearn/api/team_user/dto/TeamUserUpdateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_user/dto/TeamUserUpdateRequest.kt
@@ -1,0 +1,6 @@
+package com.jipsa.balearn.api.team_user.dto
+
+data class TeamUserUpdateRequest(
+    val nickname: String?,
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/user/UserApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/user/UserApi.kt
@@ -1,16 +1,16 @@
 package com.jipsa.balearn.api.user
 
 import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.api.team.dto.TeamCreateRequest
 import com.jipsa.balearn.api.user.dto.UserResponse
+import com.jipsa.balearn.api.user.dto.UserUpdateRequest
 import com.jipsa.balearn.common.api.ApiResponse
+import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.domain.user.UserId
 import com.jipsa.balearn.domain.user.UserService
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/user")
@@ -38,5 +38,22 @@ class UserApi(
     ): ApiResponse<Unit> {
         userService.deleteUser(user.id)
         return ApiResponse.success()
+    }
+
+    @PutMapping("/me")
+    fun updateUser(
+        @RequestPart("data") request: UserUpdateRequest,
+        @RequestPart("image", required = false) image: MultipartFile?,
+        @CurrentUser user: User
+    ): ApiResponse<UserResponse> {
+        return ApiResponse.success(
+            UserResponse.from(
+                userService.updateUser(
+                    user = user,
+                    name = request.name,
+                    phoneNumber = request.phoneNumber,
+                    image = image?.let { File.from(it) })
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/api/user/dto/UserUpdateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/user/dto/UserUpdateRequest.kt
@@ -1,0 +1,7 @@
+package com.jipsa.balearn.api.user.dto
+
+data class UserUpdateRequest(
+    val name: String?,
+    val phoneNumber: String?,
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/global/BaseEntity.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
 import com.jipsa.balearn.domain.user.UserId
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
@@ -19,6 +20,7 @@ import java.time.LocalDateTime
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity : BaseTimeEntity() {
     @CreatedBy
+    @Column(updatable = false)
     var createdBy: Long? = null
         protected set
 
@@ -34,6 +36,7 @@ abstract class BaseTimeEntity {
     @JsonSerialize(using = LocalDateTimeSerializer::class)
     @JsonDeserialize(using = LocalDateTimeDeserializer::class)
     @CreatedDate
+    @Column(updatable = false)
     var createdAt: LocalDateTime? = null
         protected set
 

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUser.kt
@@ -27,10 +27,10 @@ class TeamUser(
         )
     }
 
-    fun updateProfile(nickname: String, profileImageUrl: String) {
+    fun updateProfile(nickname: String?, profileImageUrl: String?) {
         this._profile = TeamUserProfile(
-            nickname = nickname,
-            profileImageUrl = profileImageUrl,
+            nickname = nickname ?: this._profile.nickname,
+            profileImageUrl = profileImageUrl ?: this._profile.profileImageUrl,
             role = this._profile.role
         )
     }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserImageAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserImageAppender.kt
@@ -1,0 +1,14 @@
+package com.jipsa.balearn.domain.team_user
+
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.infra.gcs.GcsFileUploader
+import org.springframework.stereotype.Component
+
+@Component
+class TeamUserImageAppender(
+    private val gcsFileUploader: GcsFileUploader
+) {
+    fun append(image: File?): String? {
+        return image?.let { gcsFileUploader.uploadImageFile(it, "teamUserProfile") }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
@@ -31,4 +31,20 @@ class TeamUserService(
             profileImageUrl = profileImgUrl
         )
     }
+
+    fun changeRole(userId: UserId, teamId: TeamId, teamUserId: TeamUserId, role: TeamUserRole): TeamUser {
+        val teamUser = teamUserReader.read(teamUserId)
+
+        teamUserValidator.validOwner(teamId, userId)
+
+        return teamUserUpdater.update(teamUser, role)
+    }
+
+    fun changeRole(userId: UserId, teamId: TeamId, role: TeamUserRole): TeamUser {
+        val teamUser = teamUserReader.readBy(teamId, userId)
+
+        teamUserValidator.validOwner(teamId, userId)
+
+        return teamUserUpdater.update(teamUser, role)
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
@@ -1,0 +1,34 @@
+package com.jipsa.balearn.domain.team_user
+
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.user.User
+import com.jipsa.balearn.domain.user.UserId
+import org.springframework.stereotype.Service
+
+@Service
+class TeamUserService(
+    private val teamUserReader: TeamUserReader,
+    private val teamUserValidator: TeamUserValidator,
+    private val teamUserUpdater: TeamUserUpdater,
+    private val teamUserImageAppender: TeamUserImageAppender
+) {
+    fun readTeamUser(teamId: TeamId, userId: UserId): TeamUser {
+        return teamUserReader.readBy(teamId, userId)
+    }
+
+    fun readTeamUser(teamId: TeamId, userId: UserId, teamUserId: TeamUserId): TeamUser {
+        teamUserValidator.validTeamUser(teamId, userId)
+        return teamUserReader.read(teamUserId)
+    }
+
+    fun updateTeamUser(userId: UserId, teamId: TeamId, nickname: String?, image: File?): TeamUser {
+        val teamUser = teamUserReader.readBy(teamId, userId)
+        val profileImgUrl = image?.let { teamUserImageAppender.append(image) }
+        return teamUserUpdater.update(
+            teamUser = teamUser,
+            nickname = nickname,
+            profileImageUrl = profileImgUrl
+        )
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserUpdater.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserUpdater.kt
@@ -1,0 +1,18 @@
+package com.jipsa.balearn.domain.team_user
+
+import org.springframework.stereotype.Component
+
+@Component
+class TeamUserUpdater(
+    private val teamUserRepository: TeamUserRepository,
+) {
+    fun update(teamUser: TeamUser, nickname: String?, profileImageUrl: String?): TeamUser {
+
+        teamUser.updateProfile(
+            nickname = nickname,
+            profileImageUrl = profileImageUrl
+        )
+
+        return teamUserRepository.save(teamUser)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserUpdater.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserUpdater.kt
@@ -15,4 +15,11 @@ class TeamUserUpdater(
 
         return teamUserRepository.save(teamUser)
     }
+
+    fun update(teamUser: TeamUser, role: TeamUserRole): TeamUser {
+
+        teamUser.changeRole(role)
+
+        return teamUserRepository.save(teamUser)
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/User.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/User.kt
@@ -2,6 +2,7 @@ package com.jipsa.balearn.domain.user
 
 import com.jipsa.balearn.domain.global.Base
 import java.time.LocalDateTime
+import javax.swing.text.html.HTML.Tag.U
 
 class User(
     val id: UserId = UserId(),
@@ -17,8 +18,13 @@ class User(
     val userProfile: UserProfile
         get() = _userProfile
 
-    fun changeProfile(userProfile: UserProfile) {
-        this._userProfile = userProfile
+    fun changeProfile(name: String?, phoneNumber: String?, profileImgUrl: String?) {
+        this._userProfile = UserProfile(
+            name = name ?: userProfile.name,
+            email = userProfile.email,
+            phoneNumber = phoneNumber ?: userProfile.phoneNumber,
+            profileImageUrl = profileImgUrl ?: userProfile.profileImageUrl
+        )
     }
 
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserImageAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserImageAppender.kt
@@ -1,14 +1,14 @@
-package com.jipsa.balearn.domain.team
+package com.jipsa.balearn.domain.user
 
 import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.infra.gcs.GcsFileUploader
 import org.springframework.stereotype.Component
 
 @Component
-class TeamImageAppender(
+class UserImageAppender(
     private val gcsFileUploader: GcsFileUploader
 ) {
     fun append(image: File?): String? {
-        return image?.let { gcsFileUploader.uploadImageFile(it, "teamProfile") }
+        return image?.let { gcsFileUploader.uploadImageFile(it, "userProfile") }
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserService.kt
@@ -31,11 +31,6 @@ class UserService(
         return userReader.read(userId)
     }
 
-    fun updateUser(userId: UserId, name: String?, phoneNumber: String?, image: File?): User {
-        val profileImgUrl = image?.let { userImageAppender.append(image) }
-        return userUpdater.update(userId, name, phoneNumber, profileImgUrl)
-    }
-
     fun updateUser(user: User, name: String?, phoneNumber: String?, image: File?): User {
         val profileImgUrl = image?.let { userImageAppender.append(image) }
         return userUpdater.update(user, name, phoneNumber, profileImgUrl)

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.jipsa.balearn.domain.user
 
+import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.infra.jwt.JwtGenerator
 import com.jipsa.balearn.infra.jwt.JwtProvider
 import com.jipsa.balearn.infra.jwt.JwtValidator
@@ -19,7 +20,8 @@ class UserService(
     private val jwtValidator: JwtValidator,
     private val tokenAppender: TokenAppender,
     private val tokenReader: TokenReader,
-    private val tokenDeleter: TokenDeleter
+    private val tokenDeleter: TokenDeleter,
+    private val userImageAppender: UserImageAppender
 ) {
     fun appendUser(user: User) {
         userAppender.append(user)
@@ -29,12 +31,14 @@ class UserService(
         return userReader.read(userId)
     }
 
-    fun updateUser(userId: UserId, name: String?, phoneNumber: String?, profileImgUrl: String?) {
-        userUpdater.update(userId, name, phoneNumber, profileImgUrl)
+    fun updateUser(userId: UserId, name: String?, phoneNumber: String?, image: File?): User {
+        val profileImgUrl = image?.let { userImageAppender.append(image) }
+        return userUpdater.update(userId, name, phoneNumber, profileImgUrl)
     }
 
-    fun updateUser(user: User, name: String?, phoneNumber: String?, profileImgUrl: String?) {
-        userUpdater.update(user, name, phoneNumber, profileImgUrl)
+    fun updateUser(user: User, name: String?, phoneNumber: String?, image: File?): User {
+        val profileImgUrl = image?.let { userImageAppender.append(image) }
+        return userUpdater.update(user, name, phoneNumber, profileImgUrl)
     }
 
     fun deleteUser(userId: UserId) {

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserUpdater.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserUpdater.kt
@@ -10,10 +10,10 @@ class UserUpdater(
     fun update(userId: UserId, name: String?, phoneNumber: String?, profileImgUrl: String?): User {
         val user = userRepository.findById(userId.value) ?: throw CustomUserException.UserNotFoundException
         val userProfile = UserProfile(
-            name ?: user.userProfile.name,
-            phoneNumber ?: user.userProfile.email,
-            profileImgUrl ?: user.userProfile.phoneNumber,
-            user.userProfile.profileImageUrl
+            name = name ?: user.userProfile.name,
+            email = user.userProfile.email,
+            phoneNumber = phoneNumber ?: user.userProfile.phoneNumber,
+            profileImageUrl = profileImgUrl ?: user.userProfile.profileImageUrl
         )
         user.changeProfile(userProfile)
         return userRepository.save(user)
@@ -21,10 +21,10 @@ class UserUpdater(
 
     fun update(user: User, name: String?, phoneNumber: String?, profileImgUrl: String?): User {
         val userProfile = UserProfile(
-            name ?: user.userProfile.name,
-            phoneNumber ?: user.userProfile.email,
-            profileImgUrl ?: user.userProfile.phoneNumber,
-            user.userProfile.profileImageUrl
+            name = name ?: user.userProfile.name,
+            email = user.userProfile.email,
+            phoneNumber = phoneNumber ?: user.userProfile.phoneNumber,
+            profileImageUrl = profileImgUrl ?: user.userProfile.profileImageUrl,
         )
         user.changeProfile(userProfile)
         return userRepository.save(user)

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/UserUpdater.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/UserUpdater.kt
@@ -7,26 +7,12 @@ import org.springframework.stereotype.Component
 class UserUpdater(
     private val userRepository: UserRepository
 ) {
-    fun update(userId: UserId, name: String?, phoneNumber: String?, profileImgUrl: String?): User {
-        val user = userRepository.findById(userId.value) ?: throw CustomUserException.UserNotFoundException
-        val userProfile = UserProfile(
-            name = name ?: user.userProfile.name,
-            email = user.userProfile.email,
-            phoneNumber = phoneNumber ?: user.userProfile.phoneNumber,
-            profileImageUrl = profileImgUrl ?: user.userProfile.profileImageUrl
-        )
-        user.changeProfile(userProfile)
-        return userRepository.save(user)
-    }
-
     fun update(user: User, name: String?, phoneNumber: String?, profileImgUrl: String?): User {
-        val userProfile = UserProfile(
-            name = name ?: user.userProfile.name,
-            email = user.userProfile.email,
-            phoneNumber = phoneNumber ?: user.userProfile.phoneNumber,
-            profileImageUrl = profileImgUrl ?: user.userProfile.profileImageUrl,
+        user.changeProfile(
+            name = name,
+            phoneNumber = phoneNumber,
+            profileImgUrl = profileImgUrl
         )
-        user.changeProfile(userProfile)
         return userRepository.save(user)
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### User 수정
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/8c9aa412-9114-4086-816e-837de7387cf1" />

- team 생성할 때 그 방식처럼 요청 보내면 됩니다.
- image나 data 안 필드는 null이어도 됨 ( null이면 수정 안됨 )

### TeamUser
- teamUser 조회 ( 내 모임원 정보 )
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/1c985eed-f47a-43af-9eaf-212d58668729" />

- teamUserId로 조회
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/4ddca05a-5481-413c-84c1-9d87a3e65a80" />

**모임에 가입되어있어야 조회 가능**

- teamUser 수정
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/c5775a29-b339-4ced-9d57-04c7b0ffcb72" />

- 이것도 team 생성, user 수정처럼 요청 보내면 됩니다.

수정api 응답값의 createdAt이 null로 나오는 이슈가 있음.
db상으로는 바뀌지 않아서 다시 조회하면 잘 나옴

- teamUser role 변경
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/2c77258b-8fc2-476e-b38c-c6f5b2707c0d" />

- role에 들어가는 param은 leader, member가 있음
- owner만 가능
- request는 teamUser 조회랑 같은 형식임

- team owner 변경
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/9d744052-7261-424d-9881-647c14e83d26" />

- 해당 멤버에게 모임 소유권 이전
- owner만 가능
- 소유권 이전 시 해당 멤버의 role이 owner, 자신은 leader로 변경

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #10
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

