### PR TITLE
[Feat/#26] leaderboard 기능 추가

### DIFF
--- a/src/main/kotlin/com/jipsa/balearn/api/mission/dto/MissionReadResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission/dto/MissionReadResponse.kt
@@ -1,8 +1,6 @@
 package com.jipsa.balearn.api.mission.dto
 
 import com.jipsa.balearn.domain.mission.Mission
-import com.jipsa.balearn.domain.notice.Notice
-import org.springframework.data.jpa.domain.AbstractAuditable_.createdBy
 import java.time.LocalDateTime
 
 data class MissionReadResponse(
@@ -11,7 +9,8 @@ data class MissionReadResponse(
     val createdAt: LocalDateTime?,
     val createdBy: Long?,
     val modifiedAt: LocalDateTime?,
-    val modifiedBy: Long?
+    val modifiedBy: Long?,
+    val clear: Boolean? = null
 ) {
     companion object {
         fun from(mission: Mission): MissionReadResponse {
@@ -22,6 +21,18 @@ data class MissionReadResponse(
                 createdBy = mission.createdBy?.value,
                 modifiedAt = mission.modifiedAt,
                 modifiedBy = mission.modifiedBy?.value
+            )
+        }
+
+        fun from(mission: Mission, clear: Boolean): MissionReadResponse {
+            return MissionReadResponse(
+                id = mission.id.value,
+                detail = mission.missionInfo.detail,
+                createdAt = mission.createdAt,
+                createdBy = mission.createdBy?.value,
+                modifiedAt = mission.modifiedAt,
+                modifiedBy = mission.modifiedBy?.value,
+                clear = clear
             )
         }
     }

--- a/src/main/kotlin/com/jipsa/balearn/api/mission_clear/LeaderboardApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission_clear/LeaderboardApi.kt
@@ -18,9 +18,10 @@ class LeaderboardApi(
     @GetMapping("/{teamId}")
     fun readLeaderboard(
         @CurrentUser user: User,
-        @PathVariable teamId: Long
+        @PathVariable teamId: Long,
+        @RequestParam(required = false) top: Int?
     ): ApiResponse<List<LeaderboardResponse>> {
-        return ApiResponse.success(missionClearService.readLeaderboard(TeamId(teamId)))
+        return ApiResponse.success(missionClearService.readLeaderboard(TeamId(teamId), top ?: 5))
     }
 
     @PostMapping("/{teamId}/clear/{missionId}")

--- a/src/main/kotlin/com/jipsa/balearn/api/mission_clear/LeaderboardApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission_clear/LeaderboardApi.kt
@@ -1,0 +1,49 @@
+package com.jipsa.balearn.api.mission_clear
+
+import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.api.mission_clear.dto.LeaderboardResponse
+import com.jipsa.balearn.api.mission_clear.dto.MissionClearResponse
+import com.jipsa.balearn.common.api.ApiResponse
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission_clear.MissionClearService
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.user.User
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/leaderboard")
+class LeaderboardApi(
+    private val missionClearService: MissionClearService
+) {
+    @GetMapping("/{teamId}")
+    fun readLeaderboard(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long
+    ): ApiResponse<List<LeaderboardResponse>> {
+        return ApiResponse.success(missionClearService.readLeaderboard(TeamId(teamId)))
+    }
+
+    @PostMapping("/{teamId}/clear/{missionId}")
+    fun createClear(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long,
+        @PathVariable missionId: Long
+    ): ApiResponse<MissionClearResponse> {
+        return ApiResponse.success(
+            MissionClearResponse.from(
+                missionClearService.appendMissionClear(TeamId(teamId), user, MissionId(missionId))
+            )
+        )
+    }
+
+    @DeleteMapping("/{teamId}/clear/{missionId}")
+    fun deleteClear(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long,
+        @PathVariable missionId: Long
+    ): ApiResponse<Unit> {
+        missionClearService.deleteMissionClear(TeamId(teamId), user, MissionId(missionId))
+        return ApiResponse.success()
+    }
+
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/mission_clear/dto/LeaderboardResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission_clear/dto/LeaderboardResponse.kt
@@ -1,0 +1,21 @@
+package com.jipsa.balearn.api.mission_clear.dto
+
+import com.jipsa.balearn.domain.team_user.TeamUser
+
+data class LeaderboardResponse(
+    val rank: Int,
+    val nickname: String,
+    val profileImgUrl: String,
+    val score: Int
+) {
+    companion object {
+        fun from(rank: Int, teamUser: TeamUser, score: Int): LeaderboardResponse {
+            return LeaderboardResponse(
+                rank = rank,
+                nickname = teamUser.profile.nickname,
+                profileImgUrl = teamUser.profile.profileImageUrl,
+                score = score
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/mission_clear/dto/MissionClearResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/mission_clear/dto/MissionClearResponse.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.api.mission_clear.dto
+
+import com.jipsa.balearn.domain.mission_clear.MissionClear
+
+data class MissionClearResponse(
+    val missionId: Long,
+    val teamUserId: Long,
+) {
+    companion object {
+        fun from(missionClear: MissionClear): MissionClearResponse {
+            return MissionClearResponse(
+                missionId = missionClear.missionClearId.missionId.value,
+                teamUserId = missionClear.missionClearId.teamUserId.value,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/schedule/ScheduleApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/schedule/ScheduleApi.kt
@@ -85,6 +85,16 @@ class ScheduleApi(
         )
     }
 
+    @GetMapping("/today/team/{teamId}")
+    fun getScheduleByToday(
+        @CurrentUser user: User,
+        @PathVariable teamId: Long
+    ): ApiResponse<List<ScheduleResponse>> {
+        return ApiResponse.success(
+            scheduleService.readDailySchedules(user, TeamId(teamId))
+        )
+    }
+
     @PutMapping("/{scheduleId}")
     fun updateSchedule(
         @CurrentUser user: User,

--- a/src/main/kotlin/com/jipsa/balearn/api/schedule/dto/ScheduleResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/schedule/dto/ScheduleResponse.kt
@@ -26,5 +26,17 @@ data class ScheduleResponse(
                 mission = missions.map { MissionReadResponse.from(it) }
             )
         }
+
+        fun fromResponse(schedule: Schedule, missionResponses: List<MissionReadResponse>): ScheduleResponse {
+            return ScheduleResponse(
+                id = schedule.id.value,
+                address = schedule.scheduleInfo.address,
+                startTime = schedule.scheduleInfo.startTime,
+                endTime = schedule.scheduleInfo.endTime,
+                topic = schedule.scheduleInfo.topic,
+                color = schedule.scheduleInfo.color,
+                mission = missionResponses
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/LeaderboardReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/LeaderboardReader.kt
@@ -12,8 +12,8 @@ class LeaderboardReader(
     private val redisRepository: RedisRepository,
     private val teamUserReader: TeamUserReader
 ) {
-    fun read(teamId: TeamId): List<LeaderboardResponse> {
-        val results = redisRepository.getTopZSet(redisRepository.generateLeaderboardKey(teamId.value), 5)
+    fun read(teamId: TeamId, topN: Int = 5): List<LeaderboardResponse> {
+        val results = redisRepository.getTopZSet(redisRepository.generateLeaderboardKey(teamId.value), topN)
         return results?.mapIndexed { index, tuple ->
             val teamUserId = tuple.value?.let { TeamUserId(it.toLong()) } // Redis에서 가져온 userId
             val score = tuple.score?.toInt() ?: 0 // 점수

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/LeaderboardReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/LeaderboardReader.kt
@@ -1,0 +1,44 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.api.mission_clear.dto.LeaderboardResponse
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.domain.team_user.TeamUserReader
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
+import org.springframework.stereotype.Component
+
+@Component
+class LeaderboardReader(
+    private val redisRepository: RedisRepository,
+    private val teamUserReader: TeamUserReader
+) {
+    fun read(teamId: TeamId): List<LeaderboardResponse> {
+        val results = redisRepository.getTopZSet(redisRepository.generateLeaderboardKey(teamId.value), 5)
+        return results?.mapIndexed { index, tuple ->
+            val teamUserId = tuple.value?.let { TeamUserId(it.toLong()) } // Redis에서 가져온 userId
+            val score = tuple.score?.toInt() ?: 0 // 점수
+
+
+            val teamUser = teamUserId?.let {
+                try {
+                    teamUserReader.read(it)
+                } catch (e: Exception) {
+                    null
+                }
+            }
+
+            teamUser?.let {
+                LeaderboardResponse.from(
+                    rank = index + 1,
+                    teamUser = it,
+                    score = score
+                )
+            } ?: LeaderboardResponse(
+                rank = index + 1,
+                nickname = "탈퇴한 유저",
+                profileImgUrl = "https://cdn.balearn.o-r.kr/profile/default-user.jpg",
+                score = score
+            )
+        } ?: emptyList()
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearAppender.kt
@@ -1,0 +1,23 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.domain.schedule.exception.CustomMissionClearException
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MissionClearAppender(
+    private val missionClearRepository: MissionClearRepository,
+    private val redisRepository: RedisRepository
+) {
+    fun append(missionClear: MissionClear): MissionClear {
+        if (missionClearRepository.existsById(missionClear.missionClearId)) {
+            throw CustomMissionClearException.AlreadyMissionClearException
+        }
+        redisRepository.addZSetScore(
+            key = redisRepository.generateLeaderboardKey(missionClear.teamUser.team.id.value),
+            value = missionClear.teamUser.id.value.toString(),
+            score = 50.0
+        )
+        return missionClearRepository.save(missionClear)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearDeleter.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearDeleter.kt
@@ -1,14 +1,25 @@
 package com.jipsa.balearn.domain.mission_clear
 
 import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.schedule.exception.CustomMissionClearException
 import com.jipsa.balearn.domain.team_user.TeamUserId
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
 import org.springframework.stereotype.Component
 
 @Component
 class MissionClearDeleter(
-    private val missionClearRepository: MissionClearRepository
+    private val missionClearRepository: MissionClearRepository,
+    private val redisRepository: RedisRepository
 ) {
     fun delete(teamUserId: TeamUserId, missionId: MissionId) {
+        if (!missionClearRepository.existsById(missionId, teamUserId)) {
+            throw CustomMissionClearException.AlreadyMissionNotClearException
+        }
         missionClearRepository.deleteById(missionId, teamUserId)
+        redisRepository.minusZSetScore(
+            key = redisRepository.generateLeaderboardKey(teamUserId.value),
+            value = teamUserId.value.toString(),
+            score = 50.0
+        )
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearReader.kt
@@ -1,0 +1,14 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.team_user.TeamUserId
+import org.springframework.stereotype.Component
+
+@Component
+class MissionClearReader(
+    private val missionClearRepository: MissionClearRepository
+) {
+    fun existsBy(missionId: MissionId, teamUserId: TeamUserId): Boolean {
+        return missionClearRepository.existsById(missionId, teamUserId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearService.kt
@@ -35,7 +35,7 @@ class MissionClearService(
         missionClearDeleter.delete(teamUser.id, missionId)
     }
 
-    fun readLeaderboard(teamId: TeamId): List<LeaderboardResponse> {
-        return leaderboardReader.read(teamId)
+    fun readLeaderboard(teamId: TeamId, topN: Int): List<LeaderboardResponse> {
+        return leaderboardReader.read(teamId, topN)
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/MissionClearService.kt
@@ -1,0 +1,41 @@
+package com.jipsa.balearn.domain.mission_clear
+
+import com.jipsa.balearn.api.mission_clear.dto.LeaderboardResponse
+import com.jipsa.balearn.domain.mission.MissionId
+import com.jipsa.balearn.domain.mission.MissionReader
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_user.TeamUserReader
+import com.jipsa.balearn.domain.user.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MissionClearService(
+    private val missionClearAppender: MissionClearAppender,
+    private val missionReader: MissionReader,
+    private val missionClearDeleter: MissionClearDeleter,
+    private val teamUserReader: TeamUserReader,
+    private val leaderboardReader: LeaderboardReader
+) {
+    @Transactional
+    fun appendMissionClear(teamId: TeamId, user: User, missionId: MissionId): MissionClear {
+        val mission = missionReader.read(missionId)
+        val teamUser = teamUserReader.readBy(teamId, user.id)
+        val missionClear = MissionClear(
+            missionClearId = MissionClearId(missionId, teamUser.id),
+            mission = mission,
+            teamUser = teamUser
+        )
+        return missionClearAppender.append(missionClear)
+    }
+
+    @Transactional
+    fun deleteMissionClear(teamId: TeamId, user: User, missionId: MissionId) {
+        val teamUser = teamUserReader.readBy(teamId, user.id)
+        missionClearDeleter.delete(teamUser.id, missionId)
+    }
+
+    fun readLeaderboard(teamId: TeamId): List<LeaderboardResponse> {
+        return leaderboardReader.read(teamId)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/exception/CustomMissionClearException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/exception/CustomMissionClearException.kt
@@ -1,0 +1,19 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomMissionClearException(errorCode: MissionClearErrorCode) : CustomException(errorCode) {
+    data object AlreadyMissionClearException :
+        CustomMissionClearException(MissionClearErrorCode.ALREADY_MISSION_CLEAR) {
+        private fun readResolve(): Any = AlreadyMissionClearException
+
+        val EXCEPTION: CustomMissionClearException = AlreadyMissionClearException
+    }
+
+    data object AlreadyMissionNotClearException :
+        CustomMissionClearException(MissionClearErrorCode.ALREADY_MISSION_NOT_CLEAR) {
+        private fun readResolve(): Any = AlreadyMissionNotClearException
+
+        val EXCEPTION: CustomMissionClearException = AlreadyMissionNotClearException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/exception/MissionClearErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/mission_clear/exception/MissionClearErrorCode.kt
@@ -1,0 +1,18 @@
+package com.jipsa.balearn.domain.schedule.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class MissionClearErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    ALREADY_MISSION_CLEAR(400, "MC001", "이미 미션을 클리어했습니다."),
+    ALREADY_MISSION_NOT_CLEAR(400, "MC002", "미션 클리어 상태가 아닙니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleReader.kt
@@ -48,6 +48,13 @@ class ScheduleReader(
         return scheduleRepository.findByStartDateAndEndDate(teamId, startOfMonth, endOfMonth)
     }
 
+    fun readDailyScheduleBy(teamId: TeamId): List<Schedule> {
+        val date = LocalDate.now()
+        val startOfDay = date.atStartOfDay()
+        val endOfDay = date.atTime(LocalTime.MAX)
+        return scheduleRepository.findByStartDateAndEndDate(teamId, startOfDay, endOfDay)
+    }
+
     fun isExistBy(teamId: TeamId, startTime: LocalDateTime, endTime: LocalDateTime) {
         if (scheduleRepository.existByStartDateAndEndDate(teamId, startTime, endTime)) {
             throw CustomScheduleException.ScheduleTimeOverlapException

--- a/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/schedule/ScheduleService.kt
@@ -1,10 +1,13 @@
 package com.jipsa.balearn.domain.schedule
 
+import com.jipsa.balearn.api.mission.dto.MissionReadResponse
 import com.jipsa.balearn.api.mission.dto.MissionUpdateRequest
 import com.jipsa.balearn.api.schedule.dto.ScheduleResponse
 import com.jipsa.balearn.domain.mission.*
+import com.jipsa.balearn.domain.mission_clear.MissionClearReader
 import com.jipsa.balearn.domain.team.TeamId
 import com.jipsa.balearn.domain.team.TeamReader
+import com.jipsa.balearn.domain.team_user.TeamUserReader
 import com.jipsa.balearn.domain.team_user.TeamUserValidator
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.domain.user.UserId
@@ -23,7 +26,9 @@ class ScheduleService(
     private val scheduleUpdater: ScheduleUpdater,
     private val missionUpdater: MissionUpdater,
     private val scheduleDeleter: ScheduleDeleter,
-    private val missionDeleter: MissionDeleter
+    private val missionDeleter: MissionDeleter,
+    private val teamUserReader: TeamUserReader,
+    private val missionClearReader: MissionClearReader
 ) {
     @Transactional
     fun appendSchedule(
@@ -97,6 +102,21 @@ class ScheduleService(
         teamUserValidator.validTeamUser(teamId, userId)
 
         return scheduleReader.readWeeklyScheduleBy(teamId, year, week)
+    }
+
+    fun readDailySchedules(user: User, teamId: TeamId): List<ScheduleResponse> {
+        val teamUser = teamUserReader.readBy(teamId, user.id)
+
+        val schedules = scheduleReader.readDailyScheduleBy(teamId)
+
+        return schedules.map { schedule ->
+            val missions = missionReader.readBy(schedule.id)
+            val missionResponse = missions.map { mission ->
+                val missionClear = missionClearReader.existsBy(mission.id, teamUser.id)
+                MissionReadResponse.from(mission, missionClear)
+            }
+            ScheduleResponse.fromResponse(schedule, missionResponse)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/jipsa/balearn/infra/redis/repository/RedisRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/redis/repository/RedisRepository.kt
@@ -2,6 +2,7 @@ package com.jipsa.balearn.infra.redis.repository
 
 import com.jipsa.balearn.domain.user.UserId
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.stereotype.Repository
 import java.util.concurrent.TimeUnit
 
@@ -11,12 +12,14 @@ class RedisRepository(
 ) {
     private val operationValue = redisTemplate.opsForValue()
     private val operationSet = redisTemplate.opsForSet()
+    private val operationZSet = redisTemplate.opsForZSet()
 
     companion object {
         private const val REFRESH_TOKEN_KEY_PREFIX = "refresh_token:"
         private const val LOGIN_TOKEN_KEY_PREFIX = "login_token:"
         private const val BLACK_LIST_TOKEN_KEY_PREFIX = "black_list_token:"
         private const val TEAM_INVITE_CODE_KEY_PREFIX = "team_invite_code:"
+        private const val LEADERBOARD_KEY_PREFIX = "leaderboard:"
     }
 
     fun saveValue(key: String, value: String, expirationTime: Long) {
@@ -52,8 +55,25 @@ class RedisRepository(
         operationSet.remove(key, value)
     }
 
+    fun addZSetScore(key: String, value: String, score: Double) {
+        operationZSet.incrementScore(key, value, score)
+    }
+
+    fun minusZSetScore(key: String, value: String, score: Double) {
+        operationZSet.incrementScore(key, value, -score)
+    }
+
+    fun getZSetScore(key: String, value: String): Double? {
+        return operationZSet.score(key, value)
+    }
+
+    fun getTopZSet(key: String, topN: Int = 5): Set<ZSetOperations.TypedTuple<String>>? {
+        return operationZSet.reverseRangeWithScores(key, 0, (topN - 1).toLong())
+    }
+
     fun generateRefreshTokenKey(userId: UserId): String = "$REFRESH_TOKEN_KEY_PREFIX${userId.value}"
     fun generateLoginTokenKey(userId: UserId): String = "$LOGIN_TOKEN_KEY_PREFIX${userId.value}"
     fun generateBlackListTokenKey(accessToken: String): String = "$BLACK_LIST_TOKEN_KEY_PREFIX${accessToken}"
     fun generateTeamInviteCodeKey(inviteCode: String): String = "$TEAM_INVITE_CODE_KEY_PREFIX${inviteCode}"
+    fun generateLeaderboardKey(leaderboardId: Long): String = "$LEADERBOARD_KEY_PREFIX${leaderboardId}"
 }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### 일일 일정 조회
<img width="1222" alt="image" src="https://github.com/user-attachments/assets/3d0371ab-89ce-45d0-8553-485d24aa7e15" />

- 현재 날짜 기준 모든 일정 조회
- 미션 클리어 상태 추가(mission.clear)

### 미션 클리어 추가
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/e1a41179-89b7-4ac9-8862-49a2c58e5e39" />

### 미션 클리어 삭제
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/af339952-93bf-48a7-be2a-6b82cafacfaa" />

### 리더보드 조회
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/c0e033b4-be4b-4bfa-9c11-1091b7ae03d1" />

- top은 상위 몇명 조회인지
- 생략시 5명이 기본

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #26 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

