### PR TITLE
[Feat/#28] 학습 자료 기능 api 추가

### DIFF
--- a/nginx/config/blue.conf
+++ b/nginx/config/blue.conf
@@ -37,4 +37,6 @@ server {
     location = /50x.html {
         root /usr/share/nginx/html;
     }
+
+    client_max_body_size 300M;
 }

--- a/nginx/config/green.conf
+++ b/nginx/config/green.conf
@@ -37,4 +37,6 @@ server {
     location = /50x.html {
         root /usr/share/nginx/html;
     }
+
+    client_max_body_size 300M;
 }

--- a/src/main/kotlin/com/jipsa/balearn/api/learning_file/LearningFileApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/learning_file/LearningFileApi.kt
@@ -1,0 +1,70 @@
+package com.jipsa.balearn.api.learning_file
+
+import com.grepp.quizy.common.dto.Page
+import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.api.learning_file.dto.LearningFileCreateRequest
+import com.jipsa.balearn.api.learning_file.dto.LearningFileResponse
+import com.jipsa.balearn.common.api.ApiResponse
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.learning_file.LearningFileId
+import com.jipsa.balearn.domain.learning_file.LearningFileService
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.user.User
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/file")
+class LearningFileApi(
+    private val learningFileService: LearningFileService
+) {
+    @GetMapping("/team/{teamId}")
+    fun getTeamLearningFile(
+        @PathVariable teamId: Long,
+        @CurrentUser user: User,
+        page: Page = Page(1, 10)
+    ): ApiResponse<List<LearningFileResponse>> {
+        return ApiResponse.success(
+            learningFileService.readLearningFilesPage(
+                teamId = TeamId(teamId),
+                user = user,
+                pageable = PageRequest.of(page.page?.minus(1) ?: 0, page.size ?: 10)
+            )
+        )
+    }
+
+    @GetMapping("/{fileId}")
+    fun getLearningFile(
+        @PathVariable fileId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<LearningFileResponse> {
+        return ApiResponse.success(learningFileService.readLearningFile(LearningFileId(fileId), user))
+    }
+
+    @PostMapping("/team/{teamId}")
+    fun createLearningFile(
+        @RequestPart("data") request: LearningFileCreateRequest,
+        @RequestPart("file", required = true) file: MultipartFile,
+        @PathVariable teamId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<LearningFileResponse> {
+        return ApiResponse.success(
+            learningFileService.appendLearningFile(
+                name = request.name,
+                file = File.from(file),
+                user = user,
+                teamId = TeamId(teamId)
+            )
+        )
+    }
+
+    @DeleteMapping("/{fileId}")
+    fun deleteLearningFile(
+        @PathVariable fileId: Long,
+        @CurrentUser user: User
+    ): ApiResponse<Unit> {
+        learningFileService.deleteLearningFile(LearningFileId(fileId), user)
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/learning_file/dto/LearningFileCreateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/learning_file/dto/LearningFileCreateRequest.kt
@@ -1,0 +1,6 @@
+package com.jipsa.balearn.api.learning_file.dto
+
+data class LearningFileCreateRequest(
+    val name: String
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/learning_file/dto/LearningFileResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/learning_file/dto/LearningFileResponse.kt
@@ -1,0 +1,34 @@
+package com.jipsa.balearn.api.learning_file.dto
+
+import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
+import com.jipsa.balearn.domain.learning_file.LearningFile
+import com.jipsa.balearn.domain.team_user.TeamUser
+import java.time.LocalDateTime
+
+data class LearningFileResponse(
+    val id: Long,
+    val name: String,
+    val fileUrl: String,
+    val size: Long,
+    val type: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: TeamUserReadResponse?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: TeamUserReadResponse?
+) {
+    companion object {
+        fun from(learningFile: LearningFile, createdBy: TeamUser?, modifiedBy: TeamUser?): LearningFileResponse {
+            return LearningFileResponse(
+                id = learningFile.id.value,
+                name = learningFile.learningFileInfo.name,
+                fileUrl = learningFile.learningFileInfo.fileUrl,
+                type = learningFile.learningFileInfo.type,
+                size = learningFile.learningFileInfo.size,
+                createdAt = learningFile.createdAt,
+                createdBy = createdBy?.let { TeamUserReadResponse.from(it) },
+                modifiedAt = learningFile.modifiedAt,
+                modifiedBy = modifiedBy?.let { TeamUserReadResponse.from(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntity.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntity.kt
@@ -2,9 +2,9 @@ package com.jipsa.balearn.database.learning_file.entity
 
 import com.jipsa.balearn.database.global.BaseEntity
 import com.jipsa.balearn.database.team.entity.TeamEntity
-import com.jipsa.balearn.domain.learning_file.LearningFIleId
-import com.jipsa.balearn.domain.learning_file.LearningFIleInfo
 import com.jipsa.balearn.domain.learning_file.LearningFile
+import com.jipsa.balearn.domain.learning_file.LearningFileId
+import com.jipsa.balearn.domain.user.UserId
 import jakarta.persistence.*
 
 @Entity
@@ -22,9 +22,13 @@ class LearningFileEntity(
     val learningFIleInfo: LearningFIleInfoVO
 ) : BaseEntity() {
     fun toDomain() = LearningFile(
-        id = LearningFIleId(id),
+        id = LearningFileId(id),
         team = team.toDomain(),
-        _learningFileInfo = learningFIleInfo.toDomain()
+        _learningFileInfo = learningFIleInfo.toDomain(),
+        createdBy = createdBy?.let { UserId(it) },
+        modifiedBy = modifiedBy?.let { UserId(it) },
+        createdAt = createdAt,
+        modifiedAt = modifiedAt
     )
 
     companion object {

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntityVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/entity/LearningFileEntityVO.kt
@@ -13,7 +13,7 @@ data class LearningFIleInfoVO(
     val fileUrl: String,
 
     @Column(nullable = false)
-    val size: Double,
+    val size: Long,
 
     @Column(nullable = false)
     val type: String

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/repository/LearningFileJpaRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/repository/LearningFileJpaRepository.kt
@@ -1,10 +1,13 @@
 package com.jipsa.balearn.database.learning_file.repository
 
 import com.jipsa.balearn.database.learning_file.entity.LearningFileEntity
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface LearningFileJpaRepository : JpaRepository<LearningFileEntity, Long> {
     fun findByTeam_Id(teamId: Long): List<LearningFileEntity>
 
     fun deleteByTeam_Id(teamId: Long)
+
+    fun findByTeam_IdOrderByCreatedAtDesc(teamId: Long, pageable: Pageable): List<LearningFileEntity>
 }

--- a/src/main/kotlin/com/jipsa/balearn/database/learning_file/repository/LearningFileRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/learning_file/repository/LearningFileRepositoryAdaptor.kt
@@ -1,10 +1,11 @@
 package com.jipsa.balearn.database.learning_file.repository
 
 import com.jipsa.balearn.database.learning_file.entity.LearningFileEntity
-import com.jipsa.balearn.domain.learning_file.LearningFIleId
 import com.jipsa.balearn.domain.learning_file.LearningFile
+import com.jipsa.balearn.domain.learning_file.LearningFileId
 import com.jipsa.balearn.domain.learning_file.LearningFileRepository
 import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import kotlin.jvm.optionals.getOrNull
 
@@ -16,15 +17,19 @@ class LearningFileRepositoryAdaptor(
         return learningFileJpaRepository.save(LearningFileEntity.from(learningFile)).toDomain()
     }
 
-    override fun findById(learningFIleId: LearningFIleId): LearningFile? {
-        return learningFileJpaRepository.findById(learningFIleId.value).getOrNull()?.toDomain()
+    override fun findById(learningFileId: LearningFileId): LearningFile? {
+        return learningFileJpaRepository.findById(learningFileId.value).getOrNull()?.toDomain()
+    }
+
+    override fun findByTeamId(teamId: TeamId, pageable: Pageable): List<LearningFile> {
+        return learningFileJpaRepository.findByTeam_IdOrderByCreatedAtDesc(teamId.value, pageable).map { it.toDomain() }
     }
 
     override fun delete(learningFile: LearningFile) {
         learningFileJpaRepository.delete(LearningFileEntity.from(learningFile))
     }
 
-    override fun deleteById(learningFIleId: LearningFIleId) {
+    override fun deleteById(learningFIleId: LearningFileId) {
         learningFileJpaRepository.deleteById(learningFIleId.value)
     }
 

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/FileAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/FileAppender.kt
@@ -1,0 +1,14 @@
+package com.jipsa.balearn.domain.learning_file
+
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.infra.gcs.GcsFileUploader
+import org.springframework.stereotype.Component
+
+@Component
+class FileAppender(
+    private val gcsFileUploader: GcsFileUploader
+) {
+    fun append(file: File): String {
+        return gcsFileUploader.uploadLearningMaterial(file, "learningFile")
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFile.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFile.kt
@@ -6,7 +6,7 @@ import com.jipsa.balearn.domain.user.UserId
 import java.time.LocalDateTime
 
 class LearningFile(
-    val id: LearningFIleId = LearningFIleId(),
+    val id: LearningFileId = LearningFileId(),
     val team: Team,
     private var _learningFileInfo: LearningFIleInfo,
     createdAt: LocalDateTime? = null,
@@ -24,5 +24,9 @@ class LearningFile(
 
     fun updateLearningFileInfo(learningFileInfo: LearningFIleInfo) {
         _learningFileInfo = learningFileInfo
+    }
+
+    fun isCreator(userId: UserId) {
+        require(createdBy == userId) { "작성자만 가능합니다." }
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileAppender.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.learning_file
+
+import org.springframework.stereotype.Component
+
+@Component
+class LearningFileAppender(
+    private val learningFileRepository: LearningFileRepository
+) {
+    fun append(learningFile: LearningFile): LearningFile {
+        return learningFileRepository.save(learningFile)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileDeleter.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileDeleter.kt
@@ -11,7 +11,7 @@ class LearningFileDeleter(
         learningFileRepository.delete(learningFIle)
     }
 
-    fun delete(learningFIleId: LearningFIleId) {
+    fun delete(learningFIleId: LearningFileId) {
         learningFileRepository.deleteById(learningFIleId)
     }
 

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileReader.kt
@@ -1,0 +1,20 @@
+package com.jipsa.balearn.domain.learning_file
+
+import com.jipsa.balearn.domain.notice.exception.CustomLearningFileException
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+
+@Component
+class LearningFileReader(
+    private val learningFileRepository: LearningFileRepository
+) {
+    fun read(learningFileId: LearningFileId): LearningFile {
+        return learningFileRepository.findById(learningFileId)
+            ?: throw CustomLearningFileException.LearningFileNotFoundException
+    }
+
+    fun readAllBy(teamId: TeamId, pageable: Pageable): List<LearningFile> {
+        return learningFileRepository.findByTeamId(teamId, pageable)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileRepository.kt
@@ -1,11 +1,13 @@
 package com.jipsa.balearn.domain.learning_file
 
 import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.data.domain.Pageable
 
 interface LearningFileRepository {
     fun save(learningFile: LearningFile): LearningFile
-    fun findById(learningFIleId: LearningFIleId): LearningFile?
-    fun deleteById(learningFIleId: LearningFIleId)
+    fun findById(learningFileId: LearningFileId): LearningFile?
+    fun deleteById(learningFIleId: LearningFileId)
     fun deleteByTeamId(teamId: TeamId)
     fun delete(learningFile: LearningFile)
+    fun findByTeamId(teamId: TeamId, pageable: Pageable): List<LearningFile>
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileService.kt
@@ -1,0 +1,82 @@
+package com.jipsa.balearn.domain.learning_file
+
+import com.jipsa.balearn.api.learning_file.dto.LearningFileResponse
+import com.jipsa.balearn.common.dto.File
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team.TeamReader
+import com.jipsa.balearn.domain.team_user.TeamUserReader
+import com.jipsa.balearn.domain.team_user.TeamUserValidator
+import com.jipsa.balearn.domain.user.User
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LearningFileService(
+    private val learningFileAppender: LearningFileAppender,
+    private val fileAppender: FileAppender,
+    private val teamUserReader: TeamUserReader,
+    private val teamReader: TeamReader,
+    private val learningFileReader: LearningFileReader,
+    private val teamUserValidator: TeamUserValidator,
+    private val learningFileDeleter: LearningFileDeleter
+) {
+    @Transactional
+    fun appendLearningFile(name: String, file: File, user: User, teamId: TeamId): LearningFileResponse {
+        val team = teamReader.read(teamId)
+        val teamUser = teamUserReader.readBy(teamId, user.id)
+
+        val fileUrl = fileAppender.append(file)
+
+        val learningFile = LearningFile(
+            team = team,
+            _learningFileInfo = LearningFIleInfo(
+                name = name,
+                fileUrl = fileUrl,
+                size = file.size,
+                type = file.contentType
+            )
+        )
+        return LearningFileResponse.from(
+            learningFile = learningFileAppender.append(learningFile),
+            createdBy = teamUser,
+            modifiedBy = teamUser
+        )
+    }
+
+    @Transactional
+    fun deleteLearningFile(learningFileId: LearningFileId, user: User) {
+        val learningFile = learningFileReader.read(learningFileId)
+
+        try {
+            teamUserValidator.validLeader(learningFile.team.id, user.id)
+        } catch (e: Exception) {
+            learningFile.isCreator(user.id)
+        }
+
+        learningFileDeleter.delete(learningFile)
+    }
+
+    fun readLearningFile(learningFileId: LearningFileId, user: User): LearningFileResponse {
+        val learningFile = learningFileReader.read(learningFileId)
+        teamUserValidator.validTeamUser(learningFile.team.id, user.id)
+
+        return LearningFileResponse.from(
+            learningFile = learningFile,
+            createdBy = learningFile.createdBy?.let { teamUserReader.readBy(learningFile.team.id, it) },
+            modifiedBy = learningFile.modifiedBy?.let { teamUserReader.readBy(learningFile.team.id, it) }
+        )
+    }
+
+    fun readLearningFilesPage(teamId: TeamId, user: User, pageable: Pageable): List<LearningFileResponse> {
+        teamUserValidator.validTeamUser(teamId, user.id)
+
+        return learningFileReader.readAllBy(teamId, pageable).map { file ->
+            LearningFileResponse.from(
+                learningFile = file,
+                createdBy = file.createdBy?.let { teamUserReader.readBy(teamId, it) },
+                modifiedBy = file.modifiedBy?.let { teamUserReader.readBy(teamId, it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/LearningFileVO.kt
@@ -1,11 +1,11 @@
 package com.jipsa.balearn.domain.learning_file
 
 @JvmInline
-value class LearningFIleId(val value: Long = 0)
+value class LearningFileId(val value: Long = 0)
 
 data class LearningFIleInfo(
     val name: String,
     val fileUrl: String,
-    val size: Double,
+    val size: Long,
     val type: String
 )

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/exception/CustomLearningFileException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/exception/CustomLearningFileException.kt
@@ -1,0 +1,12 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.jipsa.balearn.common.exception.CustomException
+
+sealed class CustomLearningFileException(errorCode: LearningFileErrorCode) : CustomException(errorCode) {
+    data object LearningFileNotFoundException :
+        CustomLearningFileException(LearningFileErrorCode.LEARNING_FILE_NOT_FOUND) {
+        private fun readResolve(): Any = LearningFileNotFoundException
+
+        val EXCEPTION: CustomLearningFileException = LearningFileNotFoundException
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/learning_file/exception/LearningFileErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/learning_file/exception/LearningFileErrorCode.kt
@@ -1,0 +1,17 @@
+package com.jipsa.balearn.domain.notice.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+
+enum class LearningFileErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    LEARNING_FILE_NOT_FOUND(404, "LEARNING_FILE_001", "해당 학습 파일을 찾을 수 없습니다."),
+    ;
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason(status, errorCode, message)
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserValidator.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserValidator.kt
@@ -24,12 +24,12 @@ class TeamUserValidator(
 
     fun validLeader(teamId: TeamId, userId: UserId) {
         teamUserRepository.findByTeamIdAndUserId(teamId, userId)?.isLeader()
-            ?: throw CustomTeamUserException.TeamUserNotValidException
+            ?: throw CustomTeamUserException.TeamUserPermissionDeniedException
     }
 
     fun validOwner(teamId: TeamId, userId: UserId) {
         teamUserRepository.findByTeamIdAndUserId(teamId, userId)?.isOwner()
-            ?: throw CustomTeamUserException.TeamUserNotValidException
+            ?: throw CustomTeamUserException.TeamUserPermissionDeniedException
     }
 
     fun isExistTeamOwner(userId: UserId) {

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
@@ -44,4 +44,11 @@ sealed class CustomTeamUserException(errorCode: TeamUserErrorCode) : CustomExcep
 
         val EXCEPTION: CustomTeamUserException = OwnerCannotLeaveException
     }
+
+    data object TeamUserPermissionDeniedException :
+        CustomTeamUserException(TeamUserErrorCode.TEAM_USER_PERMISSION_DENIED) {
+        private fun readResolve(): Any = TeamUserPermissionDeniedException
+
+        val EXCEPTION: CustomTeamUserException = TeamUserPermissionDeniedException
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
@@ -15,6 +15,7 @@ enum class TeamUserErrorCode(
     TEAM_USER_NOT_VALID(403, "TU004", "해당 모임에 가입되어있지 않습니다."),
     INVITE_CODE_NOT_VALID(403, "TU005", "해당 초대 코드가 유효하지 않습니다."),
     OWNER_CANNOT_LEAVE(403, "TU006", "모임장은 모임을 나갈 수 없습니다."),
+    TEAM_USER_PERMISSION_DENIED(403, "TU007", "해당 모임원은 대한 권한이 없습니다."),
     ;
 
     override val errorReason: ErrorReason

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,11 @@ spring:
         project-id: ${GCP_PROJECT_ID}
         bucket: ${BUCKET_NAME}
 
+  servlet:
+    multipart:
+      max-file-size: 300MB  # 업로드 가능한 파일의 최대 크기
+      max-request-size: 300MB  # 요청의 최대 크기
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 3600000  # 1시간


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### 학습자료 단일 조회
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/e77ce4ed-d021-4dfa-aa56-8ee6a81b1f94" />

### 학습 자료 페이지네이션
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/63e75731-1aec-48b3-afcd-59a883e0391d" />

- page, size는 없을시 기본으로 1, 10

###  학습자료 업로드
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/60334ea3-287f-4420-913d-bf55f827476b" />

- image아님 file임

### 학습자료 삭제
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/43c8382e-3ca8-4046-9a82-c3c4431f044d" />

- Leader 이상 혹은 내가 올린 파일만 삭제 가능

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #28 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

