### PR TITLE
[Feat/#30] 요구사항에 맞게 기능 수정

### DIFF
--- a/src/main/kotlin/com/jipsa/balearn/api/notice/NoticeApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/notice/NoticeApi.kt
@@ -4,7 +4,7 @@ import com.grepp.quizy.common.dto.Page
 import com.grepp.quizy.common.dto.PageResult
 import com.jipsa.balearn.api.global.annotation.CurrentUser
 import com.jipsa.balearn.api.notice.dto.NoticeCreateRequest
-import com.jipsa.balearn.api.notice.dto.NoticeReadResponse
+import com.jipsa.balearn.api.notice.dto.NoticeResponse
 import com.jipsa.balearn.api.notice.dto.NoticeUpdateRequest
 import com.jipsa.balearn.common.api.ApiResponse
 import com.jipsa.balearn.domain.notice.NoticeId
@@ -24,15 +24,13 @@ class NoticeApi(
     fun createNotice(
         @CurrentUser user: User,
         @RequestBody request: NoticeCreateRequest
-    ): ApiResponse<NoticeReadResponse> {
+    ): ApiResponse<NoticeResponse> {
         return ApiResponse.success(
-            NoticeReadResponse.from(
-                noticeService.appendNotice(
-                    request.title,
-                    request.detail,
-                    user.id,
-                    TeamId(request.teamId)
-                )
+            noticeService.appendNotice(
+                request.title,
+                request.detail,
+                user.id,
+                TeamId(request.teamId)
             )
         )
     }
@@ -41,11 +39,9 @@ class NoticeApi(
     fun readNotice(
         @CurrentUser user: User,
         @PathVariable noticeId: Long
-    ): ApiResponse<NoticeReadResponse> {
+    ): ApiResponse<NoticeResponse> {
         return ApiResponse.success(
-            NoticeReadResponse.from(
-                noticeService.readNotice(user.id, NoticeId(noticeId))
-            )
+            noticeService.readNotice(user.id, NoticeId(noticeId))
         )
     }
 
@@ -54,15 +50,13 @@ class NoticeApi(
         @CurrentUser user: User,
         @PathVariable teamId: Long,
         page: Page = Page(1, 10)
-    ): ApiResponse<PageResult<NoticeReadResponse>> {
+    ): ApiResponse<PageResult<NoticeResponse>> {
         return ApiResponse.success(
             noticeService.readNoticePage(
                 user.id,
                 TeamId(teamId),
                 PageRequest.of(page.page?.minus(1) ?: 0, page.size ?: 10)
-            )
-                .map { NoticeReadResponse.from(it) }
-                .let { PageResult.of(it.content, it.totalPages, it.hasNext()) }
+            ).let { PageResult.of(it.content, it.totalPages, it.hasNext()) }
         )
     }
 
@@ -71,15 +65,13 @@ class NoticeApi(
         @CurrentUser user: User,
         @PathVariable noticeId: Long,
         @RequestBody request: NoticeUpdateRequest
-    ): ApiResponse<NoticeReadResponse> {
+    ): ApiResponse<NoticeResponse> {
         return ApiResponse.success(
-            NoticeReadResponse.from(
-                noticeService.updateNotice(
-                    user = user,
-                    noticeId = NoticeId(noticeId),
-                    title = request.title,
-                    detail = request.detail
-                )
+            noticeService.updateNotice(
+                user = user,
+                noticeId = NoticeId(noticeId),
+                title = request.title,
+                detail = request.detail
             )
         )
     }

--- a/src/main/kotlin/com/jipsa/balearn/api/notice/dto/NoticeResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/notice/dto/NoticeResponse.kt
@@ -1,0 +1,30 @@
+package com.jipsa.balearn.api.notice.dto
+
+import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
+import com.jipsa.balearn.domain.notice.Notice
+import com.jipsa.balearn.domain.team_user.TeamUser
+import java.time.LocalDateTime
+
+data class NoticeResponse(
+    val id: Long,
+    val title: String,
+    val detail: String,
+    val createdAt: LocalDateTime?,
+    val createdBy: TeamUserReadResponse?,
+    val modifiedAt: LocalDateTime?,
+    val modifiedBy: TeamUserReadResponse?
+) {
+    companion object {
+        fun from(notice: Notice, createdBy: TeamUser?, modifiedBy: TeamUser?): NoticeResponse {
+            return NoticeResponse(
+                id = notice.id.value,
+                title = notice.noticeInfo.title,
+                detail = notice.noticeInfo.detail,
+                createdAt = notice.createdAt,
+                createdBy = createdBy?.let { TeamUserReadResponse.from(it) },
+                modifiedAt = notice.modifiedAt,
+                modifiedBy = modifiedBy?.let { TeamUserReadResponse.from(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/TeamApi.kt
@@ -80,7 +80,8 @@ class TeamApi(
                     name = request.name,
                     description = request.description,
                     image = image?.let { File.from(it) },
-                    user = user
+                    user = user,
+                    teamGoalsUpdateRequest = request.goals
                 )
             )
         )

--- a/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamUpdateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team/dto/TeamUpdateRequest.kt
@@ -1,7 +1,10 @@
 package com.jipsa.balearn.api.team.dto
 
+import com.jipsa.balearn.api.team_goal.dto.TeamGoalsUpdateRequest
+
 data class TeamUpdateRequest(
     val name: String?,
-    val description: String?
+    val description: String?,
+    val goals: List<TeamGoalsUpdateRequest>?
 ) {
 }

--- a/src/main/kotlin/com/jipsa/balearn/api/team_goal/dto/TeamGoalsUpdateRequest.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/team_goal/dto/TeamGoalsUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.api.team_goal.dto
+
+data class TeamGoalsUpdateRequest(
+    val id: Long,
+    val detail: String?,
+    val color: String?
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/notice/NoticeService.kt
@@ -1,7 +1,8 @@
 package com.jipsa.balearn.domain.notice
 
+import com.jipsa.balearn.api.notice.dto.NoticeResponse
 import com.jipsa.balearn.domain.team.TeamId
-import com.jipsa.balearn.domain.team.TeamReader
+import com.jipsa.balearn.domain.team_user.TeamUserReader
 import com.jipsa.balearn.domain.team_user.TeamUserValidator
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.domain.user.UserId
@@ -15,14 +16,13 @@ class NoticeService(
     private val noticeAppender: NoticeAppender,
     private val noticeReader: NoticeReader,
     private val teamUserValidator: TeamUserValidator,
-    private val teamReader: TeamReader,
     private val noticeUpdater: NoticeUpdater,
-    private val noticeDeleter: NoticeDeleter
-
+    private val noticeDeleter: NoticeDeleter,
+    private val teamUserReader: TeamUserReader
 ) {
     @Transactional
-    fun appendNotice(title: String, detail: String, userId: UserId, teamId: TeamId): Notice {
-        val team = teamReader.read(teamId)
+    fun appendNotice(title: String, detail: String, userId: UserId, teamId: TeamId): NoticeResponse {
+        val teamUser = teamUserReader.readBy(teamId, userId)
 
         teamUserValidator.validLeader(teamId, userId)
 
@@ -31,28 +31,38 @@ class NoticeService(
                 title = title,
                 detail = detail
             ),
-            team = team
+            team = teamUser.team
         )
 
-        return noticeAppender.append(notice, team)
+        val newNotice = noticeAppender.append(notice, teamUser.team)
+
+        return NoticeResponse.from(newNotice, teamUser, teamUser)
     }
 
-    fun readNotice(userId: UserId, noticeId: NoticeId): Notice {
+    fun readNotice(userId: UserId, noticeId: NoticeId): NoticeResponse {
         val notice = noticeReader.read(noticeId)
 
         teamUserValidator.validTeamUser(notice.team.id, userId)
 
-        return notice
+        val createdBy = notice.createdBy?.let { teamUserReader.readBy(notice.team.id, it) }
+        val modifiedBy = notice.modifiedBy?.let { teamUserReader.readBy(notice.team.id, it) }
+
+        return NoticeResponse.from(notice, createdBy, modifiedBy)
     }
 
-    fun readNoticePage(userId: UserId, teamId: TeamId, pageable: Pageable): Page<Notice> {
+    fun readNoticePage(userId: UserId, teamId: TeamId, pageable: Pageable): Page<NoticeResponse> {
         teamUserValidator.validTeamUser(teamId, userId)
 
-        return noticeReader.readBy(teamId, pageable)
+        return noticeReader.readBy(teamId, pageable).map { notice ->
+            val createdBy = notice.createdBy?.let { teamUserReader.readBy(notice.team.id, it) }
+            val modifiedBy = notice.modifiedBy?.let { teamUserReader.readBy(notice.team.id, it) }
+
+            NoticeResponse.from(notice, createdBy, modifiedBy)
+        }
     }
 
     @Transactional
-    fun updateNotice(user: User, noticeId: NoticeId, title: String?, detail: String?): Notice {
+    fun updateNotice(user: User, noticeId: NoticeId, title: String?, detail: String?): NoticeResponse {
         val notice = noticeReader.read(noticeId)
 
         try {
@@ -62,7 +72,11 @@ class NoticeService(
             notice.isCreator(user.id)
         }
 
-        return noticeUpdater.update(notice, title, detail)
+        val updatedNotice = noticeUpdater.update(notice, title, detail)
+        val createdBy = updatedNotice.createdBy?.let { teamUserReader.readBy(updatedNotice.team.id, it) }
+        val modifiedBy = updatedNotice.modifiedBy?.let { teamUserReader.readBy(updatedNotice.team.id, it) }
+
+        return NoticeResponse.from(updatedNotice, createdBy, modifiedBy)
     }
 
     @Transactional

--- a/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team/TeamService.kt
@@ -5,15 +5,13 @@ import com.jipsa.balearn.api.schedule.dto.ScheduleResponse
 import com.jipsa.balearn.api.team.dto.TeamReadResponse
 import com.jipsa.balearn.api.team.dto.TeamResponse
 import com.jipsa.balearn.api.team_goal.dto.TeamGoalReadResponse
+import com.jipsa.balearn.api.team_goal.dto.TeamGoalsUpdateRequest
 import com.jipsa.balearn.api.team_user.dto.TeamUserReadResponse
 import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.domain.mission.MissionReader
 import com.jipsa.balearn.domain.notice.NoticeReader
 import com.jipsa.balearn.domain.schedule.ScheduleReader
-import com.jipsa.balearn.domain.team_goal.TeamGoal
-import com.jipsa.balearn.domain.team_goal.TeamGoalAppender
-import com.jipsa.balearn.domain.team_goal.TeamGoalInfo
-import com.jipsa.balearn.domain.team_goal.TeamGoalReader
+import com.jipsa.balearn.domain.team_goal.*
 import com.jipsa.balearn.domain.team_user.*
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.domain.user.UserId
@@ -35,7 +33,8 @@ class TeamService(
     private val teamInviter: TeamInviter,
     private val teamUserValidator: TeamUserValidator,
     private val teamUpdater: TeamUpdater,
-    private val teamDeleter: TeamDeleter
+    private val teamDeleter: TeamDeleter,
+    private val teamGoalUpdater: TeamGoalUpdater
 ) {
     @Transactional
     fun createTeam(name: String, description: String, goals: List<TeamGoalInfo>?, image: File?, user: User): Team {
@@ -111,10 +110,20 @@ class TeamService(
     }
 
     @Transactional
-    fun updateTeam(teamId: TeamId, name: String?, description: String?, image: File?, user: User): Team {
+    fun updateTeam(
+        teamId: TeamId,
+        name: String?,
+        description: String?,
+        image: File?,
+        user: User,
+        teamGoalsUpdateRequest: List<TeamGoalsUpdateRequest>?
+    ): Team {
         teamUserValidator.validOwner(teamId, user.id)
+
         val team = teamReader.read(teamId)
         val imgUrl = teamImageAppender.append(image)
+
+        teamGoalUpdater.updateAll(teamGoalsUpdateRequest)
 
         return teamUpdater.update(
             team = team,

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalUpdater.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_goal/TeamGoalUpdater.kt
@@ -1,5 +1,7 @@
 package com.jipsa.balearn.domain.team_goal
 
+import com.jipsa.balearn.api.team_goal.dto.TeamGoalsUpdateRequest
+import com.jipsa.balearn.domain.schedule.exception.CustomTeamGoalException
 import org.springframework.stereotype.Component
 
 @Component
@@ -9,5 +11,15 @@ class TeamGoalUpdater(
     fun update(teamGoal: TeamGoal, detail: String?, color: String?): TeamGoal {
         teamGoal.updateInfo(detail, color)
         return teamGoalRepository.save(teamGoal)
+    }
+
+    fun updateAll(request: List<TeamGoalsUpdateRequest>?): List<TeamGoal>? {
+        val teamGoals = request?.map {
+            val teamGoal = teamGoalRepository.findById(TeamGoalId(it.id))
+                ?: throw CustomTeamGoalException.TeamGoalNotFoundException
+            teamGoal.updateInfo(it.detail, it.color)
+            teamGoal
+        }
+        return teamGoals?.let { teamGoalRepository.saveAll(it) }
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/TeamUserService.kt
@@ -2,6 +2,7 @@ package com.jipsa.balearn.domain.team_user
 
 import com.jipsa.balearn.common.dto.File
 import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team_user.exception.CustomTeamUserException
 import com.jipsa.balearn.domain.user.UserId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -35,9 +36,13 @@ class TeamUserService(
     }
 
     fun changeRole(userId: UserId, teamId: TeamId, teamUserId: TeamUserId, role: TeamUserRole): TeamUser {
+        teamUserValidator.validOwner(teamId, userId)
+
         val teamUser = teamUserReader.read(teamUserId)
 
-        teamUserValidator.validOwner(teamId, userId)
+        if (teamUser.profile.role == TeamUserRole.OWNER) {
+            throw CustomTeamUserException.OwnerCannotBeModifiedException
+        }
 
         return teamUserUpdater.update(teamUser, role)
     }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/CustomTeamUserException.kt
@@ -51,4 +51,11 @@ sealed class CustomTeamUserException(errorCode: TeamUserErrorCode) : CustomExcep
 
         val EXCEPTION: CustomTeamUserException = TeamUserPermissionDeniedException
     }
+
+    data object OwnerCannotBeModifiedException :
+        CustomTeamUserException(TeamUserErrorCode.OWNER_CANNOT_BE_MODIFIED) {
+        private fun readResolve(): Any = OwnerCannotBeModifiedException
+
+        val EXCEPTION: CustomTeamUserException = OwnerCannotBeModifiedException
+    }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/team_user/exception/TeamUserErrorCode.kt
@@ -16,6 +16,7 @@ enum class TeamUserErrorCode(
     INVITE_CODE_NOT_VALID(403, "TU005", "해당 초대 코드가 유효하지 않습니다."),
     OWNER_CANNOT_LEAVE(403, "TU006", "모임장은 모임을 나갈 수 없습니다."),
     TEAM_USER_PERMISSION_DENIED(403, "TU007", "해당 모임원은 대한 권한이 없습니다."),
+    OWNER_CANNOT_BE_MODIFIED(403, "TU008", "모임장은 수정,삭제할 수 없습니다."),
     ;
 
     override val errorReason: ErrorReason


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### 공지사항 조회
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/91df8077-c5f3-4703-b37b-bcaa20f1d987" />

- 공지사항 조회시 만든이, 수정이의 teamUser의 정보 조회
- 단, team조회시 공지사항 조회는 해당 없음

### 팀 수정시 팀 목표도 함께 수정
"data": {
    "name": "string",
    "description": "string",
    "goals": [
      {
        "id": 0,
        "detail": "string",
        "color": "string"
      }
    ]
  },

- data에 goals라는 리스트 필드 추가
- id는 수정하고자 하는 goal id

이밖에 팀 권한 수정시 owner는 나의 권한을 임의로 수정하지 못하게 변경


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #30
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

