### PR TITLE
[Feat/#39] 채팅 캐싱 및 저장, 조회 기능 추가

### DIFF
--- a/src/main/kotlin/com/jipsa/balearn/api/chat/ChatApi.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/chat/ChatApi.kt
@@ -1,6 +1,10 @@
 package com.jipsa.balearn.api.chat
 
+import com.jipsa.balearn.api.chat.dto.ChatListResponse
 import com.jipsa.balearn.api.chat.dto.ChatRequest
+import com.jipsa.balearn.api.chat.dto.ChatResponse
+import com.jipsa.balearn.api.global.annotation.CurrentUser
+import com.jipsa.balearn.common.api.ApiResponse
 import com.jipsa.balearn.domain.chat.ChatService
 import com.jipsa.balearn.domain.team.TeamId
 import com.jipsa.balearn.domain.user.User
@@ -9,7 +13,11 @@ import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
 
 @RestController
 class ChatApi(
@@ -26,5 +34,22 @@ class ChatApi(
             ?: throw CustomUserException.UserNotAuthenticatedException
 
         chatService.sendChat(TeamId(teamId), request.message, user)
+    }
+
+    @GetMapping("/api/chat/{teamId}")
+    fun getChatList(
+        @PathVariable teamId: Long,
+        @RequestParam size: Int?,
+        @RequestParam cursor: LocalDateTime?,
+        @CurrentUser user: User
+    ): ApiResponse<ChatListResponse> {
+        val chatList = chatService.getChatList(user, TeamId(teamId), cursor, size ?: 10)
+
+        return ApiResponse.success(
+            ChatListResponse(
+                contents = chatList.map { ChatResponse.from(it) },
+                cursor = chatList.lastOrNull()?.createdAt
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/api/chat/dto/ChatListResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/chat/dto/ChatListResponse.kt
@@ -1,0 +1,9 @@
+package com.jipsa.balearn.api.chat.dto
+
+import java.time.LocalDateTime
+
+data class ChatListResponse(
+    val contents: List<ChatResponse>,
+    val cursor: LocalDateTime?
+) {
+}

--- a/src/main/kotlin/com/jipsa/balearn/api/chat/dto/ChatResponse.kt
+++ b/src/main/kotlin/com/jipsa/balearn/api/chat/dto/ChatResponse.kt
@@ -6,7 +6,7 @@ import com.jipsa.balearn.domain.chat.Sender
 import java.time.LocalDateTime
 
 data class ChatResponse(
-    val id: Long,
+    val id: String,
     val teamId: Long,
     val sender: Sender,
     val message: String,

--- a/src/main/kotlin/com/jipsa/balearn/common/jackson/JacksonConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/common/jackson/JacksonConfig.kt
@@ -1,0 +1,21 @@
+package com.jipsa.balearn.common.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JacksonConfig {
+
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        return ObjectMapper().apply {
+            registerModule(JavaTimeModule()) // ✅ LocalDateTime 지원
+            registerModule(KotlinModule.Builder().build()) // ✅ Kotlin 지원
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // ✅ ISO-8601 형식으로 날짜 저장
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/common/scheduling/SchedulingConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/common/scheduling/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.common.scheduling
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling // ✅ 스케줄링 활성화
+class SchedulingConfig

--- a/src/main/kotlin/com/jipsa/balearn/common/util/toEpochMillis.kt
+++ b/src/main/kotlin/com/jipsa/balearn/common/util/toEpochMillis.kt
@@ -1,0 +1,8 @@
+package com.jipsa.balearn.common.util
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+fun LocalDateTime.toEpochMillis(): Double {
+    return this.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli().toDouble()
+}

--- a/src/main/kotlin/com/jipsa/balearn/database/chat/document/ChatDocument.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/chat/document/ChatDocument.kt
@@ -1,21 +1,22 @@
 package com.jipsa.balearn.database.chat.document
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.jipsa.balearn.domain.chat.Chat
 import com.jipsa.balearn.domain.chat.ChatId
 import com.jipsa.balearn.domain.chat.ChatInfo
 import com.jipsa.balearn.domain.chat.ChatType
 import com.jipsa.balearn.domain.team.TeamId
 import org.springframework.data.annotation.Id
-import org.springframework.data.elasticsearch.annotations.Document
-import org.springframework.data.elasticsearch.annotations.Field
-import org.springframework.data.elasticsearch.annotations.FieldType
+import org.springframework.data.elasticsearch.annotations.*
 import java.time.LocalDateTime
 
 @Document(indexName = "chat")
+@Setting(settingPath = "elasticsearch/chat-settings.json")
+@Mapping(mappingPath = "elasticsearch/chat-mappings.json")
 class ChatDocument(
     @Id
-    @Field(type = FieldType.Long)
-    val id: Long,
+    @Field(type = FieldType.Keyword)
+    val id: String,
 
     @Field(type = FieldType.Long)
     val teamId: Long,
@@ -23,15 +24,27 @@ class ChatDocument(
     @Field(type = FieldType.Object)
     val sender: SenderVO,
 
-    @Field(type = FieldType.Date)
+    @Field(
+        type = FieldType.Date_Nanos,
+        format = [DateFormat.date_hour_minute_second_millis],
+        pattern = ["yyyy-MM-dd'T'HH:mm:ss.SSSSSS"]
+    )
     val createdAt: LocalDateTime,
 
-    @Field(type = FieldType.Date)
+    @Field(
+        type = FieldType.Date_Nanos,
+        format = [DateFormat.date_hour_minute_second_millis],
+        pattern = ["yyyy-MM-dd'T'HH:mm:ss.SSSSSS"]
+    )
     val modifiedAt: LocalDateTime,
 
-    @Field(type = FieldType.Text)
+    @Field(type = FieldType.Text, analyzer = "standard")
     val message: String,
 
+    @Field(type = FieldType.Keyword)
+    val messageKeyword: String = message,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @Field(type = FieldType.Keyword)
     val type: ChatType
 ) {
@@ -48,12 +61,13 @@ class ChatDocument(
 
     companion object {
         fun from(chat: Chat): ChatDocument {
+            val now = LocalDateTime.now()
             return ChatDocument(
                 id = chat.id.value,
                 teamId = chat.teamId.value,
                 sender = SenderVO.from(chat.sender),
-                createdAt = chat.createdAt ?: LocalDateTime.now(),
-                modifiedAt = chat.modifiedAt ?: LocalDateTime.now(),
+                createdAt = chat.createdAt ?: now,
+                modifiedAt = chat.modifiedAt ?: now,
                 message = chat.chatInfo.message,
                 type = chat.chatInfo.type
             )

--- a/src/main/kotlin/com/jipsa/balearn/database/chat/document/ChatDocumentVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/chat/document/ChatDocumentVO.kt
@@ -1,5 +1,6 @@
 package com.jipsa.balearn.database.chat.document
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.jipsa.balearn.domain.chat.Sender
 import com.jipsa.balearn.domain.team_user.TeamUserId
 import com.jipsa.balearn.domain.team_user.TeamUserRole
@@ -17,6 +18,7 @@ data class SenderVO(
     val profileImageUrl: String,
 
     @Field(type = FieldType.Keyword)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     val role: TeamUserRole
 ) {
     fun toDomain(): Sender {

--- a/src/main/kotlin/com/jipsa/balearn/database/chat/repository/ChatEsRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/chat/repository/ChatEsRepository.kt
@@ -1,10 +1,47 @@
 package com.jipsa.balearn.database.chat.repository
 
 import com.jipsa.balearn.database.chat.document.ChatDocument
+import org.springframework.data.domain.Pageable
+import org.springframework.data.elasticsearch.annotations.Query
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
-import org.springframework.stereotype.Repository
 
-@Repository
-interface ChatDocumentRepository : ElasticsearchRepository<ChatDocument, Long> {
+interface ChatEsRepository : ElasticsearchRepository<ChatDocument, String> {
     fun findByTeamId(teamId: Long): List<ChatDocument>
+
+    @Query(
+        """
+{
+  "bool": {
+    "must": [
+      { "term": { "teamId": "?0" } },
+      { "range": { "createdAt": { "lt": "?1" } } }
+    ]
+  }
+}
+"""
+    )
+    fun findByTeamIdAndCreatedAtBefore(
+        teamId: Long,
+        createdAt: String,
+        pageable: Pageable
+    ): List<ChatDocument>
+
+    @Query(
+        """
+{
+  "bool": {
+    "must": [
+      { "term": { "teamId": "?0" } },
+      { "range": { "createdAt": { "gte": "?1", "lte": "?2" } } }
+    ]
+  }
+}
+"""
+    )
+    fun findChatsInRange(
+        teamId: Long,
+        start: String,
+        end: String,
+        pageable: Pageable
+    ): List<ChatDocument>
 }

--- a/src/main/kotlin/com/jipsa/balearn/database/chat/repository/ChatRepositoryAdaptor.kt
+++ b/src/main/kotlin/com/jipsa/balearn/database/chat/repository/ChatRepositoryAdaptor.kt
@@ -1,0 +1,82 @@
+package com.jipsa.balearn.database.chat.repository
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient
+import co.elastic.clients.elasticsearch.core.BulkRequest
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jipsa.balearn.database.chat.document.ChatDocument
+import com.jipsa.balearn.domain.chat.Chat
+import com.jipsa.balearn.domain.chat.ChatRepository
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.data.domain.Pageable
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+
+@Repository
+class ChatRepositoryAdaptor(
+    private val chatEsRepository: ChatEsRepository,
+    private val elasticsearchOperations: ElasticsearchOperations,
+    private val elasticsearchClient: ElasticsearchClient,
+    private val objectMapper: ObjectMapper
+) : ChatRepository {
+    override fun findByTeamIdAndCursor(teamId: TeamId, cursor: LocalDateTime, pageable: Pageable): List<Chat> {
+        return chatEsRepository.findByTeamIdAndCreatedAtBefore(
+            teamId.value,
+            cursor.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")),
+            pageable
+        )
+            .map { it.toDomain() }
+    }
+
+    override fun findByTeamIdBetween(
+        teamId: TeamId,
+        start: LocalDateTime,
+        end: LocalDateTime,
+        pageable: Pageable
+    ): List<Chat> {
+        return chatEsRepository.findChatsInRange(
+            teamId.value,
+            start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")),
+            end.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")),
+            pageable
+        )
+            .map { it.toDomain() }
+    }
+
+    override fun saveChatsBulk(chats: List<Chat>) {
+        if (chats.isEmpty()) return // 빈 리스트는 처리하지 않음.
+
+        val chatDocuments = chats.map {
+            ChatDocument.from(it)
+        }
+
+        val bulkRequest = BulkRequest.of { b ->
+            b.operations(
+                chatDocuments.map { chat ->
+                    BulkOperation.of { op ->
+                        op.index { idx ->
+                            idx.index("chat")
+                                .document(chat)
+                        }
+                    }
+                }
+            )
+        }
+
+        val response = elasticsearchClient.bulk(bulkRequest)
+
+        if (response.errors()) {
+            response.items().forEachIndexed { index, item ->
+                // 만약 어떤 Item에서 에러가 발생했으면, 오류 내용 확인
+                val error = item.error()
+                if (error != null) {
+                    println("Bulk insert error at index $index : $error")
+                }
+            }
+            throw IllegalArgumentException("Elasticsearch Bulk Insert 에러")
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/Chat.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/Chat.kt
@@ -11,8 +11,8 @@ class Chat(
     val teamId: TeamId,
     val sender: Sender,
     val chatInfo: ChatInfo,
-    createdAt: LocalDateTime? = null,
-    modifiedAt: LocalDateTime? = null,
+    createdAt: LocalDateTime,
+    modifiedAt: LocalDateTime,
 ) : Serializable, Base(
     createdAt = createdAt,
     modifiedAt = modifiedAt
@@ -21,8 +21,8 @@ class Chat(
         id: ChatId = ChatId(),
         teamUser: TeamUser,
         chatInfo: ChatInfo,
-        createdAt: LocalDateTime? = null,
-        modifiedAt: LocalDateTime? = null,
+        createdAt: LocalDateTime,
+        modifiedAt: LocalDateTime,
     ) : this(
         id = id,
         teamId = teamUser.team.id,

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatAppender.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatAppender.kt
@@ -1,11 +1,36 @@
 package com.jipsa.balearn.domain.chat
 
+import com.jipsa.balearn.common.util.toEpochMillis
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
 import org.springframework.stereotype.Component
 
 @Component
-class ChatAppender {
+class ChatAppender(
+    private val chatRepository: ChatRepository,
+    private val redisRepository: RedisRepository
+) {
     // TODO: 채팅 저장 구현하기
     fun append(chat: Chat): Chat {
         return chat
+    }
+
+    fun appendInRedis(chat: Chat) {
+        val chatKey = redisRepository.generateChatKey(chat.teamId.value)
+        val newChatKey = redisRepository.generateChatBatchKey()
+        redisRepository.addChatZSetScore(chatKey, chat, chat.createdAt!!.toEpochMillis())
+        redisRepository.addChatList(newChatKey, chat)
+    }
+
+    fun appendInRedisBatch(teamId: TeamId, chatList: List<Chat>) {
+        val chatKey = redisRepository.generateChatKey(teamId.value)
+
+        val valueWithScores = chatList.associateBy({ it }, { it.createdAt!!.toEpochMillis() })
+
+        return redisRepository.addChatZSetScores(chatKey, valueWithScores)
+    }
+
+    fun appendInElasticsearchBatch(chatList: List<Chat>) {
+        chatRepository.saveChatsBulk(chatList)
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatDeleter.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatDeleter.kt
@@ -1,0 +1,29 @@
+package com.jipsa.balearn.domain.chat
+
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ChatDeleter(
+    private val chatRepository: ChatRepository,
+    private val redisRepository: RedisRepository
+) {
+    fun deleteChatInRedisBatch() {
+        redisRepository.delete(redisRepository.generateChatBatchKey())
+    }
+
+    fun decreaseChatInRedis() {
+        val maxMessagesPerTeam = 1000
+
+        val teamKeys = redisRepository.scanForKeys(redisRepository.generateChatKeyPattern())
+
+        teamKeys.forEach { teamKey ->
+            val currentSize = redisRepository.getZSetSize(teamKey)
+
+            if (currentSize > maxMessagesPerTeam) {
+                val excessCount = currentSize - maxMessagesPerTeam
+                redisRepository.removeRangeZSet(teamKey, 0, excessCount - 1) // 오래된 메시지 삭제
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatReader.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatReader.kt
@@ -1,0 +1,38 @@
+package com.jipsa.balearn.domain.chat
+
+import com.jipsa.balearn.common.util.toEpochMillis
+import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.infra.redis.repository.RedisRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class ChatReader(
+    private val chatRepository: ChatRepository,
+    private val redisRepository: RedisRepository
+) {
+    fun readInRedis(teamId: TeamId, cursor: LocalDateTime?, pageable: Pageable): List<Chat> {
+        val chatKey = redisRepository.generateChatKey(teamId.value)
+        val endScore = cursor?.toEpochMillis()?.minus(0.1) ?: System.currentTimeMillis().toDouble()
+        val startScore = Double.NEGATIVE_INFINITY
+        return redisRepository.getChatZSetValue(chatKey, startScore, endScore, pageable).toList()
+    }
+
+    fun readInRedisBatch(): List<Chat> {
+        return redisRepository.getChatList(redisRepository.generateChatBatchKey())
+    }
+
+    fun readInElasticsearch(
+        teamId: TeamId,
+        start: LocalDateTime = LocalDateTime.now().minusDays(3),
+        end: LocalDateTime = LocalDateTime.now(),
+        pageable: Pageable
+    ): List<Chat> {
+        return chatRepository.findByTeamIdBetween(teamId, start, end, pageable)
+    }
+
+    fun readInElasticsearch(teamId: TeamId, cursor: LocalDateTime?, pageable: Pageable): List<Chat> {
+        return chatRepository.findByTeamIdAndCursor(teamId, cursor ?: LocalDateTime.now(), pageable)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatRepository.kt
@@ -1,0 +1,11 @@
+package com.jipsa.balearn.domain.chat
+
+import com.jipsa.balearn.domain.team.TeamId
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+interface ChatRepository {
+    fun findByTeamIdAndCursor(teamId: TeamId, cursor: LocalDateTime, pageable: Pageable): List<Chat>
+    fun saveChatsBulk(chats: List<Chat>)
+    fun findByTeamIdBetween(teamId: TeamId, start: LocalDateTime, end: LocalDateTime, pageable: Pageable): List<Chat>
+}

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatService.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatService.kt
@@ -1,9 +1,14 @@
 package com.jipsa.balearn.domain.chat
 
 import com.jipsa.balearn.domain.team.TeamId
+import com.jipsa.balearn.domain.team.TeamReader
 import com.jipsa.balearn.domain.team_user.TeamUserReader
+import com.jipsa.balearn.domain.team_user.TeamUserValidator
 import com.jipsa.balearn.domain.user.User
 import com.jipsa.balearn.infra.redis.ChatPublisher
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -12,21 +17,67 @@ import java.time.LocalDateTime
 class ChatService(
     private val chatPublisher: ChatPublisher,
     private val teamUserReader: TeamUserReader,
-    private val chatAppender: ChatAppender
+    private val teamUserValidator: TeamUserValidator,
+    private val chatAppender: ChatAppender,
+    private val chatReader: ChatReader,
+    private val teamReader: TeamReader,
+    private val chatDeleter: ChatDeleter
 ) {
     @Transactional
     fun sendChat(teamId: TeamId, message: String, user: User) {
         val teamUser = teamUserReader.readBy(teamId, user.id)
+        val now = LocalDateTime.now()
         val chat = Chat(
             teamUser = teamUser,
             chatInfo = ChatInfo(
                 message,
                 ChatType.TALK
             ),
-            createdAt = LocalDateTime.now(),
-            modifiedAt = LocalDateTime.now()
+            createdAt = now,
+            modifiedAt = now
         )
-        chatAppender.append(chat)
+        chatAppender.appendInRedis(chat)
         chatPublisher.publish(chat)
+    }
+
+    fun getChatList(user: User, teamId: TeamId, cursor: LocalDateTime?, size: Int): List<Chat> {
+        teamUserValidator.validTeamUser(teamId, user.id)
+        val chatList =
+            chatReader.readInRedis(teamId, cursor, PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt")))
+        if (chatList.size < size) {
+            return chatList + chatReader.readInElasticsearch(
+                teamId,
+                cursor,
+                PageRequest.of(0, size - chatList.size, Sort.by(Sort.Direction.DESC, "createdAt"))
+            )
+        }
+        return chatList
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 60000)
+    fun appendChatInElasticsearch() {
+        chatAppender.appendInElasticsearchBatch(chatReader.readInRedisBatch())
+        chatDeleter.deleteChatInRedisBatch()
+    }
+
+//    @Transactional
+//    @Scheduled(cron = "0 0 4 */3 * ?")
+//    fun syncChat() {
+//        val teamList = teamReader.readAll()
+//
+//        teamList.forEach { team ->
+//            val chatList = chatReader.readInElasticsearch(teamId = team.id, pageable = Pageable.ofSize(100))
+//            chatList.isNotEmpty().let {
+//                val oldChatList = chatReader.readInRedis(team.id, null, Pageable.ofSize(100))
+//
+//                chatAppender.appendInRedisBatch(team.id, chatList)
+//            }
+//        }
+//    }
+
+    @Scheduled(fixedRate = 360000)
+    fun decreaseChatInRedis() {
+        chatDeleter.decreaseChatInRedis()
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatVO.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/chat/ChatVO.kt
@@ -1,18 +1,20 @@
 package com.jipsa.balearn.domain.chat
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonValue
 import com.jipsa.balearn.domain.team_user.TeamUser
 import com.jipsa.balearn.domain.team_user.TeamUserId
 import com.jipsa.balearn.domain.team_user.TeamUserRole
 
 @JvmInline
-value class ChatId(@JsonValue val value: Long = 0)
+value class ChatId(@JsonValue val value: String = "0")
 
 data class ChatInfo(
     val message: String,
     val type: ChatType
 )
 
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 enum class ChatType(type: String) {
     ENTER("입장"),
     EXIT("퇴장"),

--- a/src/main/kotlin/com/jipsa/balearn/domain/user/TokenDeleter.kt
+++ b/src/main/kotlin/com/jipsa/balearn/domain/user/TokenDeleter.kt
@@ -12,12 +12,12 @@ class TokenDeleter(
     private val cookieUtil: CookieUtil
 ) {
     fun deleteLoginToken(response: HttpServletResponse, userId: UserId) {
-        redisRepository.deleteValue(redisRepository.generateLoginTokenKey(userId))
+        redisRepository.delete(redisRepository.generateLoginTokenKey(userId))
         cookieUtil.deleteCookie(response, BalearnConstants.LOGIN_TOKEN)
     }
 
     fun deleteRefreshToken(response: HttpServletResponse, userId: UserId) {
-        redisRepository.deleteValue(redisRepository.generateRefreshTokenKey(userId))
+        redisRepository.delete(redisRepository.generateRefreshTokenKey(userId))
         cookieUtil.deleteCookie(response, BalearnConstants.REFRESH_TOKEN)
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/infra/elasticsearch/ElasticsearchConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/elasticsearch/ElasticsearchConfig.kt
@@ -1,0 +1,39 @@
+package com.jipsa.balearn.infra.elasticsearch
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient
+import co.elastic.clients.json.jackson.JacksonJsonpMapper
+import co.elastic.clients.transport.ElasticsearchTransport
+import co.elastic.clients.transport.rest_client.RestClientTransport
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.http.HttpHost
+import org.elasticsearch.client.RestClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ElasticsearchConfig(
+) {
+
+    @Bean
+    fun elasticsearchTransport(
+        objectMapper: ObjectMapper,
+        @Value("\${elasticsearch.host}") host: String,
+        @Value("\${elasticsearch.port}") port: Int
+    ): ElasticsearchTransport {
+        // RestClient를 생성
+        val restClient = RestClient.builder(HttpHost(host, port)).build()
+
+        // 여기서 Spring Bean으로 등록된 ObjectMapper를 활용
+        val jacksonJsonpMapper = JacksonJsonpMapper(objectMapper)
+
+        // 커스텀 Mapper를 포함한 Transport 생성
+        return RestClientTransport(restClient, jacksonJsonpMapper)
+    }
+
+    @Bean
+    fun elasticsearchClient(transport: ElasticsearchTransport): ElasticsearchClient {
+        // 위에서 만든 Transport로 ElasticsearchClient 생성
+        return ElasticsearchClient(transport)
+    }
+}

--- a/src/main/kotlin/com/jipsa/balearn/infra/redis/ChatPublisher.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/redis/ChatPublisher.kt
@@ -1,17 +1,18 @@
 package com.jipsa.balearn.infra.redis
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.jipsa.balearn.common.constants.BalearnConstants
 import com.jipsa.balearn.domain.chat.Chat
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 
 @Component
 class ChatPublisher(
-    @Qualifier("anyRedisTemplate")
-    private val redisTemplate: RedisTemplate<String, Any>,
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper
 ) {
     fun publish(chat: Chat) {
-        redisTemplate.convertAndSend(BalearnConstants.CHAT_TOPIC, chat)
+        val jsonChat = objectMapper.writeValueAsString(chat)
+        redisTemplate.convertAndSend(BalearnConstants.CHAT_TOPIC, jsonChat)
     }
 }

--- a/src/main/kotlin/com/jipsa/balearn/infra/redis/config/RedisConfig.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/redis/config/RedisConfig.kt
@@ -1,20 +1,15 @@
 package com.jipsa.balearn.infra.redis.config
 
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.jipsa.balearn.common.constants.BalearnConstants
 import com.jipsa.balearn.infra.redis.ChatSubscriber
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.listener.PatternTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
@@ -30,7 +25,6 @@ class RedisConfig {
         return LettuceConnectionFactory(host, port)
     }
 
-    @Primary
     @Bean
     fun redisTemplate(): RedisTemplate<String, String> {
         val template = RedisTemplate<String, String>()
@@ -48,29 +42,6 @@ class RedisConfig {
 
         template.setEnableTransactionSupport(true)
 
-        return template
-    }
-
-    @Bean
-    fun anyRedisTemplate(connectionFactory: RedisConnectionFactory?): RedisTemplate<String, Any> {
-        val template = RedisTemplate<String, Any>()
-        template.connectionFactory = connectionFactory
-
-        // 최신 방식의 ObjectMapper 설정
-        val objectMapper = JsonMapper.builder()
-            .addModule(JavaTimeModule()) // LocalDateTime 지원 추가
-            .addModule(KotlinModule.Builder().build()) // Kotlin 데이터 클래스 지원
-            .build()
-
-        // JSON 직렬화 설정
-        val jackson2JsonRedisSerializer = Jackson2JsonRedisSerializer(objectMapper, Any::class.java)
-
-        template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = jackson2JsonRedisSerializer
-        template.hashKeySerializer = StringRedisSerializer()
-        template.hashValueSerializer = jackson2JsonRedisSerializer
-
-        template.setEnableTransactionSupport(true)
         return template
     }
 

--- a/src/main/kotlin/com/jipsa/balearn/infra/redis/repository/RedisRepository.kt
+++ b/src/main/kotlin/com/jipsa/balearn/infra/redis/repository/RedisRepository.kt
@@ -1,18 +1,24 @@
 package com.jipsa.balearn.infra.redis.repository
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jipsa.balearn.domain.chat.Chat
 import com.jipsa.balearn.domain.user.UserId
+import org.springframework.data.domain.Pageable
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ScanOptions
 import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.stereotype.Repository
 import java.util.concurrent.TimeUnit
 
 @Repository
 class RedisRepository(
-    private val redisTemplate: RedisTemplate<String, String>
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper
 ) {
     private val operationValue = redisTemplate.opsForValue()
     private val operationSet = redisTemplate.opsForSet()
     private val operationZSet = redisTemplate.opsForZSet()
+    private val operationList = redisTemplate.opsForList()
 
     companion object {
         private const val REFRESH_TOKEN_KEY_PREFIX = "refresh_token:"
@@ -20,6 +26,8 @@ class RedisRepository(
         private const val BLACK_LIST_TOKEN_KEY_PREFIX = "black_list_token:"
         private const val TEAM_INVITE_CODE_KEY_PREFIX = "team_invite_code:"
         private const val LEADERBOARD_KEY_PREFIX = "leaderboard:"
+        private const val CHAT_KEY_PREFIX = "chat:team:"
+        private const val CHAT_BATCH_KEY_PREFIX = "chat:batch:"
     }
 
     fun saveValue(key: String, value: String, expirationTime: Long) {
@@ -34,7 +42,7 @@ class RedisRepository(
         return operationValue[key] != null
     }
 
-    fun deleteValue(key: String) {
+    fun delete(key: String) {
         redisTemplate.delete(key)
     }
 
@@ -79,9 +87,82 @@ class RedisRepository(
         return operationZSet.reverseRangeWithScores(key, 0, (topN - 1).toLong())
     }
 
+    fun addChatZSetScore(key: String, chat: Chat, score: Double) {
+        val jsonChat = objectMapper.writeValueAsString(chat)
+        operationZSet.add(key, jsonChat, score)
+    }
+
+    fun addChatZSetScores(key: String, valuesWithScores: Map<Chat, Double>) {
+        val tupleSet = valuesWithScores.map { (value, score) ->
+            ZSetOperations.TypedTuple.of(objectMapper.writeValueAsString(value), score)
+        }.toSet()
+
+        operationZSet.add(key, tupleSet)
+    }
+
+    fun getChatZSetValue(key: String, startScore: Double, endScore: Double, pageable: Pageable): Set<Chat> {
+        operationZSet.reverseRangeByScore(
+            key,
+            startScore,
+            endScore,
+            0,
+            pageable.pageSize.toLong()
+        )?.let { chatSet ->
+            return chatSet.map { objectMapper.readValue(it, Chat::class.java) }.toSet()
+        } ?: return emptySet()
+    }
+
+    fun getChatZSetValue(key: String, startScore: Double, endScore: Double): Set<Chat>? {
+        operationZSet.reverseRangeByScore(
+            key,
+            startScore,
+            endScore
+        )?.let { chatSet ->
+            return chatSet.map { objectMapper.readValue(it, Chat::class.java) }.toSet()
+        } ?: return emptySet()
+    }
+
+    fun addChatList(key: String, chat: Chat) {
+        val jsonChat = objectMapper.writeValueAsString(chat)
+        operationList.leftPush(key, jsonChat)
+    }
+
+    fun getChatList(key: String, start: Long = 0, end: Long = -1): List<Chat> {
+        return operationList.range(key, start, end)?.map { objectMapper.readValue(it, Chat::class.java) } ?: emptyList()
+    }
+
+    fun getZSetSize(key: String): Long {
+        return operationZSet.size(key) ?: 0
+    }
+
+    fun removeRangeZSet(key: String, start: Long, end: Long) {
+        operationZSet.removeRange(key, start, end)
+    }
+
+    fun scanForKeys(pattern: String): List<String> {
+        return redisTemplate.execute { connection ->
+            val keys = mutableListOf<String>()
+            val options = ScanOptions.scanOptions()
+                .match(pattern)
+                .count(1000) // 한 번에 최대 1000개 조회
+                .build()
+
+            connection.keyCommands().scan(options).use { cursor ->
+                while (cursor.hasNext()) {
+                    keys.add(String(cursor.next()))
+                }
+            }
+
+            keys
+        } ?: emptyList()
+    }
+
     fun generateRefreshTokenKey(userId: UserId): String = "$REFRESH_TOKEN_KEY_PREFIX${userId.value}"
     fun generateLoginTokenKey(userId: UserId): String = "$LOGIN_TOKEN_KEY_PREFIX${userId.value}"
     fun generateBlackListTokenKey(accessToken: String): String = "$BLACK_LIST_TOKEN_KEY_PREFIX${accessToken}"
     fun generateTeamInviteCodeKey(inviteCode: String): String = "$TEAM_INVITE_CODE_KEY_PREFIX${inviteCode}"
     fun generateLeaderboardKey(teamId: Long): String = "$LEADERBOARD_KEY_PREFIX${teamId}"
+    fun generateChatKey(teamId: Long): String = "$CHAT_KEY_PREFIX$teamId"
+    fun generateChatBatchKey(): String = CHAT_BATCH_KEY_PREFIX
+    fun generateChatKeyPattern(): String = "$CHAT_KEY_PREFIX*"
 }

--- a/src/main/resources/elasticsearch/chat-mappings.json
+++ b/src/main/resources/elasticsearch/chat-mappings.json
@@ -1,0 +1,45 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "id": {
+      "type": "keyword"
+    },
+    "teamId": {
+      "type": "long"
+    },
+    "sender": {
+      "properties": {
+        "id": {
+          "type": "long"
+        },
+        "nickname": {
+          "type": "text"
+        },
+        "profileImageUrl": {
+          "type": "text"
+        },
+        "role": {
+          "type": "keyword"
+        }
+      }
+    },
+    "createdAt": {
+      "type": "date_nanos",
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+    },
+    "modifiedAt": {
+      "type": "date_nanos",
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+    },
+    "message": {
+      "type": "text",
+      "analyzer": "standard"
+    },
+    "messageKeyword": {
+      "type": "keyword"
+    },
+    "type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/chat-settings.json
+++ b/src/main/resources/elasticsearch/chat-settings.json
@@ -1,0 +1,6 @@
+{
+  "index": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1
+  }
+}


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### 채팅 조회
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/1a282031-4ee8-45a6-ab68-173877c525d2" />

- cursor와 size를 쿼리 파라미터로
- cursor는 없을 시 현재시간, size는 없을 시 10의 값을 가지고 있음

<img width="654" alt="image" src="https://github.com/user-attachments/assets/1155c34a-c19e-45db-bc77-2fe880d0ab7e" />

- cursor 값은 마지막 채팅의 createdAt임
- 다음 요청(채팅 스크롤)시 cursor 파라미터 값을 이걸로 주면 됨

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #39
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

